### PR TITLE
Add hover tooltip for counter tracks

### DIFF
--- a/src/ui/counter_track.cpp
+++ b/src/ui/counter_track.cpp
@@ -10,6 +10,8 @@ float CounterTrackRenderer::render(ImDrawList* dl, ImVec2 area_min, float y_offs
     float total_height = 0.0f;
     uint32_t color_idx = 0;
 
+    layouts_.clear();
+
     for (const auto& series : model.counter_series_) {
         if (series.pid != pid) continue;
         if (series.points.empty()) continue;
@@ -116,32 +118,37 @@ void CounterTrackRenderer::render_series(ImDrawList* dl, ImVec2 track_min, ImVec
     dl->PopClipRect();
 }
 
-bool CounterTrackRenderer::hit_test(float mouse_x, float mouse_y, float track_left, float track_width,
-                                    const ViewState& view, CounterHitResult& result) const {
+bool counter_lookup_value(const CounterSeries& series, double time, double& out_timestamp, double& out_value) {
+    if (series.points.empty()) return false;
+
+    auto it = std::upper_bound(series.points.begin(), series.points.end(), time,
+                               [](double t, const std::pair<double, double>& p) { return t < p.first; });
+
+    // Before first data point — no value to show
+    if (it == series.points.begin()) return false;
+
+    --it;
+    out_timestamp = it->first;
+    out_value = it->second;
+    return true;
+}
+
+bool CounterTrackRenderer::hit_test(float mouse_x, float mouse_y, const ViewState& view,
+                                    CounterHitResult& result) const {
     for (const auto& layout : layouts_) {
         if (mouse_y < layout.track_min.y || mouse_y >= layout.track_max.y) continue;
         if (mouse_x < layout.track_min.x || mouse_x >= layout.track_max.x) continue;
 
         const auto& series = *layout.series;
-        if (series.points.empty()) continue;
+        float track_w = layout.track_max.x - layout.track_min.x;
+        double mouse_time = view.x_to_time(mouse_x, layout.track_min.x, track_w);
 
-        double mouse_time = view.x_to_time(mouse_x, track_left, track_width);
+        double ts, val;
+        if (!counter_lookup_value(series, mouse_time, ts, val)) continue;
 
-        // Find the last point at or before mouse_time (step function: value holds until next point)
-        auto it = std::upper_bound(series.points.begin(), series.points.end(), mouse_time,
-                                   [](double t, const std::pair<double, double>& p) { return t < p.first; });
-
-        if (it == series.points.begin()) {
-            // Before first point
-            result.series = &series;
-            result.timestamp = series.points.front().first;
-            result.value = series.points.front().second;
-        } else {
-            --it;
-            result.series = &series;
-            result.timestamp = it->first;
-            result.value = it->second;
-        }
+        result.series = &series;
+        result.timestamp = ts;
+        result.value = val;
         return true;
     }
     return false;

--- a/src/ui/counter_track.h
+++ b/src/ui/counter_track.h
@@ -10,6 +10,10 @@ struct CounterHitResult {
     double value = 0.0;
 };
 
+// Find the last counter point at or before the given time (step-function lookup).
+// Returns false if time is before the first point or series is empty.
+bool counter_lookup_value(const CounterSeries& series, double time, double& out_timestamp, double& out_value);
+
 class CounterTrackRenderer {
 public:
     // Renders all counter tracks for a given process below the thread tracks.
@@ -21,12 +25,8 @@ public:
     void render_series(ImDrawList* dl, ImVec2 track_min, ImVec2 track_max, const CounterSeries& series,
                        const ViewState& view, ImU32 color);
 
-    // Clear stored layouts (call before render_tracks loop)
-    void clear_layouts() { layouts_.clear(); }
-
     // Hit test: returns true if mouse is over a counter track, fills result
-    bool hit_test(float mouse_x, float mouse_y, float track_left, float track_width, const ViewState& view,
-                  CounterHitResult& result) const;
+    bool hit_test(float mouse_x, float mouse_y, const ViewState& view, CounterHitResult& result) const;
 
 private:
     struct Layout {

--- a/src/ui/timeline_view.cpp
+++ b/src/ui/timeline_view.cpp
@@ -72,7 +72,6 @@ void TimelineView::render_tracks(ImDrawList* dl, ImVec2 area_min, ImVec2 area_ma
     float clip_bottom = area_max.y;
 
     track_layouts_.clear();
-    counter_renderer_.clear_layouts();
     sel_rect_valid_ = false;
 
     dl->PushClipRect(ImVec2(area_min.x, clip_top), area_max, true);
@@ -737,10 +736,8 @@ void TimelineView::render(const TraceModel& model, ViewState& view) {
             ImGui::EndTooltip();
         } else {
             // Check counter tracks
-            float track_left = canvas_min.x + view.label_width;
-            float track_width = canvas_size.x - view.label_width;
             CounterHitResult counter_hit;
-            if (counter_renderer_.hit_test(io.MousePos.x, io.MousePos.y, track_left, track_width, view, counter_hit)) {
+            if (counter_renderer_.hit_test(io.MousePos.x, io.MousePos.y, view, counter_hit)) {
                 char time_buf[64];
                 ImGui::BeginTooltip();
 

--- a/tests/test_counter_track.cpp
+++ b/tests/test_counter_track.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include "ui/counter_track.h"
+
+static CounterSeries make_series(std::vector<std::pair<double, double>> points) {
+    CounterSeries s;
+    s.name = "test";
+    s.points = std::move(points);
+    return s;
+}
+
+TEST(CounterLookup, EmptySeries) {
+    CounterSeries s = make_series({});
+    double ts, val;
+    EXPECT_FALSE(counter_lookup_value(s, 100.0, ts, val));
+}
+
+TEST(CounterLookup, BeforeFirstPoint) {
+    CounterSeries s = make_series({{10.0, 5.0}, {20.0, 10.0}});
+    double ts, val;
+    EXPECT_FALSE(counter_lookup_value(s, 5.0, ts, val));
+}
+
+TEST(CounterLookup, ExactlyAtFirstPoint) {
+    CounterSeries s = make_series({{10.0, 5.0}, {20.0, 10.0}});
+    double ts, val;
+    EXPECT_TRUE(counter_lookup_value(s, 10.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 10.0);
+    EXPECT_DOUBLE_EQ(val, 5.0);
+}
+
+TEST(CounterLookup, BetweenPoints) {
+    CounterSeries s = make_series({{10.0, 5.0}, {20.0, 10.0}, {30.0, 15.0}});
+    double ts, val;
+    // Between first and second — should return first point's value (step function)
+    EXPECT_TRUE(counter_lookup_value(s, 15.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 10.0);
+    EXPECT_DOUBLE_EQ(val, 5.0);
+
+    // Between second and third
+    EXPECT_TRUE(counter_lookup_value(s, 25.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 20.0);
+    EXPECT_DOUBLE_EQ(val, 10.0);
+}
+
+TEST(CounterLookup, ExactlyAtSecondPoint) {
+    CounterSeries s = make_series({{10.0, 5.0}, {20.0, 10.0}});
+    double ts, val;
+    EXPECT_TRUE(counter_lookup_value(s, 20.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 20.0);
+    EXPECT_DOUBLE_EQ(val, 10.0);
+}
+
+TEST(CounterLookup, AfterLastPoint) {
+    CounterSeries s = make_series({{10.0, 5.0}, {20.0, 10.0}});
+    double ts, val;
+    EXPECT_TRUE(counter_lookup_value(s, 999.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 20.0);
+    EXPECT_DOUBLE_EQ(val, 10.0);
+}
+
+TEST(CounterLookup, SinglePoint) {
+    CounterSeries s = make_series({{42.0, 7.0}});
+    double ts, val;
+
+    EXPECT_FALSE(counter_lookup_value(s, 41.0, ts, val));
+
+    EXPECT_TRUE(counter_lookup_value(s, 42.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 42.0);
+    EXPECT_DOUBLE_EQ(val, 7.0);
+
+    EXPECT_TRUE(counter_lookup_value(s, 100.0, ts, val));
+    EXPECT_DOUBLE_EQ(ts, 42.0);
+    EXPECT_DOUBLE_EQ(val, 7.0);
+}


### PR DESCRIPTION
## Summary
- Show counter name, value, and timestamp when hovering over counter track lines in the timeline
- Uses step-function lookup (value holds until next data point) to find the relevant value at the mouse position
- Returns no tooltip when hovering before the first data point in a series

## Test plan
- [x] Unit tests for `counter_lookup_value()` covering empty series, before first point, between points, exact matches, after last point, and single-point series
- [x] Manual: load a trace with counter tracks, hover over the line and verify tooltip shows correct values
- [x] Manual: hover before the first data point and verify no tooltip appears
