### PR TITLE
Add flame graph panel

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -184,6 +184,7 @@ void App::update() {
         ImGui::DockBuilderDockWindow("Diagnostics", dock_left);
         ImGui::DockBuilderDockWindow("Timeline", dock_main);
         ImGui::DockBuilderDockWindow("Source", dock_main);
+        ImGui::DockBuilderDockWindow("Flame Graph", dock_main);
         ImGui::DockBuilderDockWindow("Details", dock_right);
         ImGui::DockBuilderDockWindow("Filters", dock_right);
         ImGui::DockBuilderDockWindow("Search", dock_bottom);
@@ -222,6 +223,7 @@ void App::update() {
         instances_.render(model_, view_);
         diagnostics_.stats = timeline_.diag_stats;
         source_.render(model_, view_);
+        flamegraph_.render(model_, view_);
         diagnostics_.render(model_, view_);
     } else {
         // Welcome screen
@@ -255,6 +257,10 @@ void App::update() {
         ImGui::End();
 
         ImGui::Begin("Source");
+        ImGui::TextDisabled("No trace loaded.");
+        ImGui::End();
+
+        ImGui::Begin("Flame Graph");
         ImGui::TextDisabled("No trace loaded.");
         ImGui::End();
 

--- a/src/app.h
+++ b/src/app.h
@@ -14,6 +14,7 @@
 #include "ui/instance_panel.h"
 #include "ui/diagnostics_panel.h"
 #include "ui/source_panel.h"
+#include "ui/flamegraph_panel.h"
 #include "model/query_db.h"
 #include <string>
 #include <vector>
@@ -45,6 +46,7 @@ private:
     InstancePanel instances_;
     DiagnosticsPanel diagnostics_;
     SourcePanel source_;
+    FlameGraphPanel flamegraph_;
     QueryDb query_db_;
 
     bool has_trace_ = false;

--- a/src/ui/INDEX.md
+++ b/src/ui/INDEX.md
@@ -10,6 +10,7 @@ float time_to_x(double ts, float timeline_left, float timeline_width) const;
 double x_to_time(float x, float timeline_left, float timeline_width) const;
 void zoom_to_fit(double min_ts, double max_ts);
 void navigate_to_event(int32_t ev_idx, const TraceEvent& ev, double pad_factor = 0.5, double min_pad_us = 100.0);
+uint32_t filter_generation;  // bumped on any hidden_pids/tids/cats change
 ```
 
 ## timeline_view.h / timeline_view.cpp — main timeline: ruler, tracks, event boxes, zoom/pan, range selection
@@ -62,6 +63,14 @@ std::string remap_source_path(const std::string& trace_path, const std::string& 
 void render(const TraceModel&, ViewState&);
 nlohmann::json save_settings() const;
 void load_settings(const nlohmann::json&);
+```
+
+## flamegraph_panel.h / flamegraph_panel.cpp — aggregated flame graph: merges call stacks by (name, category), click-to-zoom, icicle toggle
+```
+void render(const TraceModel&, ViewState&);
+void rebuild(const TraceModel&, const ViewState&);  // exposed for testing
+const std::vector<FlameNode>& nodes() const;        // exposed for testing
+size_t root() const;                                // exposed for testing
 ```
 
 ## counter_track.h / counter_track.cpp — renders counter series as step-function graphs; sub-pixel merging + hover hit-test

--- a/src/ui/filter_panel.cpp
+++ b/src/ui/filter_panel.cpp
@@ -15,6 +15,7 @@ void FilterPanel::render(const TraceModel& model, ViewState& view) {
                     view.hidden_pids.erase(proc.pid);
                 else
                     view.hidden_pids.insert(proc.pid);
+                view.filter_generation++;
             }
             ImGui::SameLine();
 
@@ -26,6 +27,7 @@ void FilterPanel::render(const TraceModel& model, ViewState& view) {
                             view.hidden_tids.erase(thread.tid);
                         else
                             view.hidden_tids.insert(thread.tid);
+                        view.filter_generation++;
                     }
                     ImGui::SameLine();
                     ImGui::Text("%s (%u events)", thread.name.c_str(), (unsigned)thread.event_indices.size());
@@ -39,10 +41,12 @@ void FilterPanel::render(const TraceModel& model, ViewState& view) {
     if (ImGui::CollapsingHeader("Categories", ImGuiTreeNodeFlags_DefaultOpen)) {
         if (ImGui::Button("All")) {
             view.hidden_cats.clear();
+            view.filter_generation++;
         }
         ImGui::SameLine();
         if (ImGui::Button("None")) {
             for (uint32_t c : model.categories_) view.hidden_cats.insert(c);
+            view.filter_generation++;
         }
 
         for (uint32_t cat_idx : model.categories_) {
@@ -53,6 +57,7 @@ void FilterPanel::render(const TraceModel& model, ViewState& view) {
                     view.hidden_cats.erase(cat_idx);
                 else
                     view.hidden_cats.insert(cat_idx);
+                view.filter_generation++;
             }
         }
     }

--- a/src/ui/flamegraph_panel.cpp
+++ b/src/ui/flamegraph_panel.cpp
@@ -1,0 +1,335 @@
+#include "ui/flamegraph_panel.h"
+#include "ui/format_time.h"
+#include "model/color_palette.h"
+#include "imgui.h"
+#include <algorithm>
+#include <stack>
+
+void FlameGraphPanel::render(const TraceModel& model, ViewState& view) {
+    ImGui::Begin("Flame Graph");
+
+    if (model.events_.empty()) {
+        ImGui::TextDisabled("No trace loaded.");
+        ImGui::End();
+        return;
+    }
+
+    bool needs_rebuild = cached_event_count_ != model.events_.size() || cached_has_range_ != view.has_range_selection ||
+                         cached_filter_gen_ != view.filter_generation;
+    if (view.has_range_selection && !needs_rebuild) {
+        needs_rebuild = cached_range_start_ != view.range_start_ts || cached_range_end_ != view.range_end_ts;
+    }
+
+    if (needs_rebuild) {
+        // Save zoom target for restore after rebuild
+        if (zoom_root_ < nodes_.size() && zoom_root_ != root_idx_) {
+            zoom_name_idx_ = nodes_[zoom_root_].name_idx;
+            zoom_cat_idx_ = nodes_[zoom_root_].cat_idx;
+        } else {
+            zoom_name_idx_ = UINT32_MAX;
+        }
+
+        rebuild(model, view);
+
+        // Restore zoom by (name, cat) if possible
+        zoom_stack_.clear();
+        zoom_root_ = root_idx_;
+        if (zoom_name_idx_ != UINT32_MAX) {
+            size_t found = find_node(zoom_name_idx_, zoom_cat_idx_);
+            if (found != SIZE_MAX) {
+                zoom_stack_.push_back(root_idx_);
+                zoom_root_ = found;
+            }
+        }
+    }
+
+    // Controls
+    ImGui::Checkbox("Icicle (top-down)", &icicle_mode_);
+    ImGui::SameLine();
+    if (zoom_stack_.empty()) {
+        ImGui::BeginDisabled();
+        ImGui::Button("Reset Zoom");
+        ImGui::EndDisabled();
+    } else {
+        if (ImGui::Button("Reset Zoom")) {
+            zoom_stack_.clear();
+            zoom_root_ = root_idx_;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Zoom Out")) {
+            zoom_root_ = zoom_stack_.back();
+            zoom_stack_.pop_back();
+        }
+    }
+    if (view.has_range_selection) {
+        ImGui::SameLine();
+        char buf[64];
+        format_time(view.range_end_ts - view.range_start_ts, buf, sizeof(buf));
+        ImGui::TextDisabled("(range: %s)", buf);
+    }
+
+    ImGui::Separator();
+    render_bars(model, view);
+    ImGui::End();
+}
+
+void FlameGraphPanel::rebuild(const TraceModel& model, const ViewState& view) {
+    nodes_.clear();
+    nodes_.push_back({});  // root sentinel
+    nodes_[0].name_idx = UINT32_MAX;
+    root_idx_ = 0;
+
+    std::vector<uint32_t> stack;  // reused per event
+
+    for (const auto& proc : model.processes_) {
+        if (view.hidden_pids.count(proc.pid)) continue;
+
+        for (const auto& thread : proc.threads) {
+            for (uint32_t ev_idx : thread.event_indices) {
+                const auto& ev = model.events_[ev_idx];
+
+                if (ev.ph != Phase::Complete && ev.ph != Phase::DurationBegin) continue;
+                if (ev.is_end_event || ev.dur <= 0.0) continue;
+
+                if (view.has_range_selection) {
+                    if (ev.end_ts() <= view.range_start_ts || ev.ts >= view.range_end_ts) continue;
+                }
+                if (view.hidden_tids.count(ev.tid)) continue;
+                if (view.hidden_cats.count(ev.cat_idx)) continue;
+
+                // Build call stack (root first). Parent events with hidden categories
+                // still appear as interior nodes to preserve stack context.
+                stack.clear();
+                stack.push_back(ev_idx);
+                int32_t parent = ev.parent_idx;
+                while (parent >= 0) {
+                    const auto& pev = model.events_[parent];
+                    if (!pev.is_end_event) stack.push_back((uint32_t)parent);
+                    parent = pev.parent_idx;
+                }
+                std::reverse(stack.begin(), stack.end());
+
+                // Merge stack into flame tree
+                size_t cur = root_idx_;
+                for (size_t i = 0; i < stack.size(); i++) {
+                    const auto& sev = model.events_[stack[i]];
+
+                    // Find or create child matching (name, category)
+                    size_t child = SIZE_MAX;
+                    for (size_t ci : nodes_[cur].children) {
+                        if (nodes_[ci].name_idx == sev.name_idx && nodes_[ci].cat_idx == sev.cat_idx) {
+                            child = ci;
+                            break;
+                        }
+                    }
+                    if (child == SIZE_MAX) {
+                        child = nodes_.size();
+                        nodes_.push_back({});
+                        nodes_[child].name_idx = sev.name_idx;
+                        nodes_[child].cat_idx = sev.cat_idx;
+                        nodes_[cur].children.push_back(child);
+                    }
+
+                    // Accumulate time only at leaf (the event itself)
+                    if (i == stack.size() - 1) {
+                        double dur = ev.dur;
+                        if (view.has_range_selection) {
+                            dur = std::max(
+                                0.0, std::min(ev.end_ts(), view.range_end_ts) - std::max(ev.ts, view.range_start_ts));
+                        }
+                        nodes_[child].total_time += dur;
+                        nodes_[child].call_count++;
+                    }
+                    cur = child;
+                }
+            }
+        }
+    }
+
+    // Bottom-up pass: propagate total_time and compute self_time.
+    // Leaf nodes already have total_time from accumulation above.
+    // Interior nodes with call_count > 0 were also leaves in some stacks —
+    // their total_time already includes children (it's the event duration).
+    // Interior nodes with call_count == 0 are pure context parents —
+    // their total_time comes entirely from children.
+    std::vector<size_t> order;
+    order.reserve(nodes_.size());
+    {
+        std::stack<size_t> work;
+        work.push(root_idx_);
+        while (!work.empty()) {
+            size_t n = work.top();
+            work.pop();
+            order.push_back(n);
+            for (size_t c : nodes_[n].children) work.push(c);
+        }
+    }
+    for (auto it = order.rbegin(); it != order.rend(); ++it) {
+        auto& node = nodes_[*it];
+        if (node.children.empty()) {
+            node.self_time = node.total_time;
+            continue;
+        }
+        double children_total = 0.0;
+        for (size_t c : node.children) children_total += nodes_[c].total_time;
+        if (node.call_count == 0) {
+            node.total_time = children_total;
+            for (size_t c : node.children) node.call_count += nodes_[c].call_count;
+        }
+        node.self_time = std::max(0.0, node.total_time - children_total);
+    }
+
+    // Root total
+    double root_total = 0.0;
+    for (size_t c : nodes_[root_idx_].children) root_total += nodes_[c].total_time;
+    nodes_[root_idx_].total_time = root_total;
+
+    // Sort children by total_time descending
+    sort_node(root_idx_);
+
+    cached_event_count_ = model.events_.size();
+    cached_has_range_ = view.has_range_selection;
+    cached_range_start_ = view.range_start_ts;
+    cached_range_end_ = view.range_end_ts;
+    cached_filter_gen_ = view.filter_generation;
+}
+
+void FlameGraphPanel::sort_node(size_t idx) {
+    auto& ch = nodes_[idx].children;
+    std::sort(ch.begin(), ch.end(), [this](size_t a, size_t b) { return nodes_[a].total_time > nodes_[b].total_time; });
+    for (size_t c : ch) sort_node(c);
+}
+
+size_t FlameGraphPanel::find_node(uint32_t name_idx, uint32_t cat_idx) const {
+    std::stack<size_t> work;
+    for (size_t c : nodes_[root_idx_].children) work.push(c);
+    while (!work.empty()) {
+        size_t n = work.top();
+        work.pop();
+        if (nodes_[n].name_idx == name_idx && nodes_[n].cat_idx == cat_idx) return n;
+        for (size_t c : nodes_[n].children) work.push(c);
+    }
+    return SIZE_MAX;
+}
+
+void FlameGraphPanel::render_bars(const TraceModel& model, ViewState& view) {
+    if (nodes_.empty()) return;
+
+    constexpr float BAR_H = 20.0f, BAR_GAP = 1.0f, MIN_W = 1.0f;
+    float canvas_w = ImGui::GetContentRegionAvail().x;
+    float canvas_h = ImGui::GetContentRegionAvail().y;
+    if (canvas_w < 10.0f || canvas_h < BAR_H) return;
+
+    double root_time = nodes_[zoom_root_].total_time;
+    if (root_time <= 0.0) {
+        ImGui::TextDisabled("No duration events in range.");
+        return;
+    }
+
+    // Max depth from zoom root
+    int max_depth = 0;
+    {
+        std::stack<std::pair<size_t, int>> work;
+        work.push({zoom_root_, 0});
+        while (!work.empty()) {
+            auto [n, d] = work.top();
+            work.pop();
+            if (d > max_depth) max_depth = d;
+            for (size_t c : nodes_[n].children) work.push({c, d + 1});
+        }
+    }
+
+    float total_h = (max_depth + 1) * (BAR_H + BAR_GAP);
+
+    ImGui::BeginChild("##FlameCanvas", ImVec2(0, 0), ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar);
+    bool hoverable = ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
+    ImVec2 origin = ImGui::GetCursorScreenPos();
+    canvas_w = ImGui::GetContentRegionAvail().x;
+    ImGui::Dummy(ImVec2(canvas_w, total_h));
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    ImVec2 mouse = ImGui::GetMousePos();
+    size_t hovered = SIZE_MAX;
+
+    struct Entry {
+        size_t node;
+        int depth;
+        float x, w;
+    };
+    std::vector<Entry> queue;
+    queue.reserve(nodes_.size());
+    queue.push_back({zoom_root_, 0, 0.0f, canvas_w});
+
+    for (size_t qi = 0; qi < queue.size(); qi++) {
+        auto [ni, depth, x_off, x_w] = queue[qi];
+        const auto& node = nodes_[ni];
+        bool is_sentinel = (ni == zoom_root_ && node.name_idx == UINT32_MAX);
+
+        float y =
+            icicle_mode_ ? origin.y + depth * (BAR_H + BAR_GAP) : origin.y + total_h - (depth + 1) * (BAR_H + BAR_GAP);
+
+        if (!is_sentinel && x_w >= MIN_W) {
+            float x0 = origin.x + x_off, x1 = x0 + x_w;
+            ImU32 fill = ColorPalette::color_for_event(node.cat_idx, node.name_idx);
+
+            dl->AddRectFilled({x0, y}, {x1, y + BAR_H}, fill);
+            dl->AddRect({x0, y}, {x1, y + BAR_H}, ColorPalette::border_color(fill));
+
+            const std::string& name = model.get_string(node.name_idx);
+            if (x_w > 40.0f && !name.empty()) {
+                ImU32 tcol = ColorPalette::text_color(fill);
+                ImVec2 tsz = ImGui::CalcTextSize(name.c_str());
+                float ty = y + (BAR_H - tsz.y) * 0.5f;
+                if (tsz.x <= x_w - 4.0f) {
+                    dl->AddText({x0 + (x_w - tsz.x) * 0.5f, ty}, tcol, name.c_str());
+                } else {
+                    dl->PushClipRect({x0 + 2, y}, {x1 - 2, y + BAR_H});
+                    dl->AddText({x0 + 2, ty}, tcol, name.c_str());
+                    dl->PopClipRect();
+                }
+            }
+
+            if (hoverable && mouse.x >= x0 && mouse.x < x1 && mouse.y >= y && mouse.y < y + BAR_H) {
+                hovered = ni;
+                if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !node.children.empty()) {
+                    zoom_stack_.push_back(zoom_root_);
+                    zoom_root_ = ni;
+                }
+            }
+        }
+
+        // Enqueue children
+        float cx = is_sentinel ? 0.0f : x_off;
+        for (size_t ci : node.children) {
+            float cw = (float)(nodes_[ci].total_time / root_time) * canvas_w;
+            if (cw >= 0.5f) queue.push_back({ci, depth + 1, cx, cw});
+            cx += cw;
+        }
+    }
+
+    if (hovered != SIZE_MAX) {
+        const auto& node = nodes_[hovered];
+        char tbuf[64], sbuf[64];
+        format_time(node.total_time, tbuf, sizeof(tbuf));
+        format_time(node.self_time, sbuf, sizeof(sbuf));
+        float pct = (float)(node.total_time / root_time * 100.0);
+
+        ImGui::BeginTooltip();
+        ImGui::Text("%s", model.get_string(node.name_idx).c_str());
+        const auto& cat = model.get_string(node.cat_idx);
+        if (!cat.empty()) ImGui::TextDisabled("Category: %s", cat.c_str());
+        ImGui::Separator();
+        ImGui::Text("Total: %s (%.1f%%)", tbuf, pct);
+        ImGui::Text("Self:  %s", sbuf);
+        ImGui::Text("Calls: %u", node.call_count);
+        if (node.call_count > 1) {
+            char abuf[64];
+            format_time(node.total_time / node.call_count, abuf, sizeof(abuf));
+            ImGui::Text("Avg:   %s", abuf);
+        }
+        ImGui::TextDisabled("Click to zoom in");
+        ImGui::EndTooltip();
+    }
+
+    ImGui::EndChild();
+}

--- a/src/ui/flamegraph_panel.h
+++ b/src/ui/flamegraph_panel.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "model/trace_model.h"
+#include "ui/view_state.h"
+#include <vector>
+
+class FlameGraphPanel {
+public:
+    void render(const TraceModel& model, ViewState& view);
+
+    struct FlameNode {
+        uint32_t name_idx = 0;
+        uint32_t cat_idx = 0;
+        double total_time = 0.0;
+        double self_time = 0.0;
+        uint32_t call_count = 0;
+        std::vector<size_t> children;  // indices into nodes_
+    };
+
+    // Exposed for testing
+    const std::vector<FlameNode>& nodes() const { return nodes_; }
+    size_t root() const { return root_idx_; }
+    void rebuild(const TraceModel& model, const ViewState& view);
+
+private:
+    std::vector<FlameNode> nodes_;
+    size_t root_idx_ = 0;
+
+    std::vector<size_t> zoom_stack_;
+    size_t zoom_root_ = 0;
+    uint32_t zoom_name_idx_ = UINT32_MAX;
+    uint32_t zoom_cat_idx_ = UINT32_MAX;
+
+    double cached_range_start_ = -1.0;
+    double cached_range_end_ = -1.0;
+    bool cached_has_range_ = false;
+    size_t cached_event_count_ = 0;
+    uint32_t cached_filter_gen_ = UINT32_MAX;
+
+    bool icicle_mode_ = false;
+
+    void render_bars(const TraceModel& model, ViewState& view);
+    void sort_node(size_t idx);
+    size_t find_node(uint32_t name_idx, uint32_t cat_idx) const;
+};

--- a/src/ui/view_state.h
+++ b/src/ui/view_state.h
@@ -34,10 +34,13 @@ struct ViewState {
         range_end_ts = 0.0;
     }
 
-    // Filtering
+    // Filtering.
+    // IMPORTANT: bump filter_generation after ANY mutation of hidden_pids/tids/cats.
+    // Panels (e.g. FlameGraphPanel) use it to detect stale caches.
     std::unordered_set<uint32_t> hidden_pids;
     std::unordered_set<uint32_t> hidden_tids;
     std::unordered_set<uint32_t> hidden_cats;
+    uint32_t filter_generation = 0;
 
     // Search
     std::string search_query;

--- a/tests/test_flamegraph_panel.cpp
+++ b/tests/test_flamegraph_panel.cpp
@@ -1,0 +1,306 @@
+#include <gtest/gtest.h>
+#include "ui/flamegraph_panel.h"
+
+// main [0,100) -> foo [10,50), bar [60,90)
+static TraceModel make_model() {
+    TraceModel m;
+    uint32_t nm = m.intern_string("main"), nf = m.intern_string("foo");
+    uint32_t nb = m.intern_string("bar"), cat = m.intern_string("test");
+
+    auto& proc = m.get_or_create_process(1);
+    auto& t = proc.get_or_create_thread(1);
+
+    auto push = [&](uint32_t name, uint32_t c, double ts, double dur, uint8_t depth, int32_t parent, double self) {
+        TraceEvent e;
+        e.name_idx = name;
+        e.cat_idx = c;
+        e.ph = Phase::Complete;
+        e.ts = ts;
+        e.dur = dur;
+        e.pid = 1;
+        e.tid = 1;
+        e.depth = depth;
+        e.parent_idx = parent;
+        e.self_time = self;
+        uint32_t idx = (uint32_t)m.events_.size();
+        m.events_.push_back(e);
+        t.event_indices.push_back(idx);
+    };
+
+    push(nm, cat, 0, 100, 0, -1, 30);  // 0: main
+    push(nf, cat, 10, 40, 1, 0, 40);   // 1: foo
+    push(nb, cat, 60, 30, 1, 0, 30);   // 2: bar
+    m.min_ts_ = 0;
+    m.max_ts_ = 100;
+    return m;
+}
+
+static const FlameGraphPanel::FlameNode& find(const FlameGraphPanel& p, const TraceModel& m, const std::string& name,
+                                              size_t parent) {
+    for (size_t ci : p.nodes()[parent].children)
+        if (m.get_string(p.nodes()[ci].name_idx) == name) return p.nodes()[ci];
+    ADD_FAILURE() << "node " << name << " not found";
+    static FlameGraphPanel::FlameNode dummy;
+    return dummy;
+}
+
+TEST(FlameGraph, TreeStructure) {
+    auto m = make_model();
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    ASSERT_EQ(p.nodes()[p.root()].children.size(), 1u);
+    size_t main_n = p.nodes()[p.root()].children[0];
+    EXPECT_EQ(m.get_string(p.nodes()[main_n].name_idx), "main");
+    EXPECT_EQ(p.nodes()[main_n].children.size(), 2u);
+}
+
+TEST(FlameGraph, TimeAggregation) {
+    auto m = make_model();
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    size_t mn = p.nodes()[p.root()].children[0];
+    EXPECT_DOUBLE_EQ(p.nodes()[mn].total_time, 100.0);
+    EXPECT_DOUBLE_EQ(p.nodes()[mn].self_time, 30.0);
+
+    auto& foo = find(p, m, "foo", mn);
+    EXPECT_DOUBLE_EQ(foo.total_time, 40.0);
+    EXPECT_DOUBLE_EQ(foo.self_time, 40.0);
+    EXPECT_EQ(foo.call_count, 1u);
+
+    auto& bar = find(p, m, "bar", mn);
+    EXPECT_DOUBLE_EQ(bar.total_time, 30.0);
+    EXPECT_EQ(bar.call_count, 1u);
+}
+
+TEST(FlameGraph, CrossThreadMerging) {
+    TraceModel m;
+    uint32_t na = m.intern_string("A"), cat = m.intern_string("c");
+    auto& proc = m.get_or_create_process(1);
+    proc.get_or_create_thread(1);
+    proc.get_or_create_thread(2);
+
+    auto push = [&](uint32_t tid, double dur) {
+        TraceEvent e;
+        e.name_idx = na;
+        e.cat_idx = cat;
+        e.ph = Phase::Complete;
+        e.ts = 0;
+        e.dur = dur;
+        e.pid = 1;
+        e.tid = tid;
+        e.parent_idx = -1;
+        e.self_time = dur;
+        uint32_t idx = (uint32_t)m.events_.size();
+        m.events_.push_back(e);
+        proc.find_thread(tid)->event_indices.push_back(idx);
+    };
+    push(1, 50);
+    push(2, 30);
+
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    ASSERT_EQ(p.nodes()[p.root()].children.size(), 1u);
+    auto& a = p.nodes()[p.nodes()[p.root()].children[0]];
+    EXPECT_DOUBLE_EQ(a.total_time, 80.0);
+    EXPECT_EQ(a.call_count, 2u);
+}
+
+TEST(FlameGraph, ZeroDurationSkipped) {
+    TraceModel m;
+    uint32_t n = m.intern_string("z"), c = m.intern_string("c");
+    auto& t = m.get_or_create_process(1).get_or_create_thread(1);
+    TraceEvent e;
+    e.name_idx = n;
+    e.cat_idx = c;
+    e.ph = Phase::Complete;
+    e.dur = 0;
+    e.pid = 1;
+    e.tid = 1;
+    e.parent_idx = -1;
+    m.events_.push_back(e);
+    t.event_indices.push_back(0);
+
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+    EXPECT_TRUE(p.nodes()[p.root()].children.empty());
+}
+
+TEST(FlameGraph, RangeExclusion) {
+    auto m = make_model();
+    ViewState v;
+    v.has_range_selection = true;
+    v.range_start_ts = 0;
+    v.range_end_ts = 55;  // excludes bar [60,90)
+
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+    size_t mn = p.nodes()[p.root()].children[0];
+    ASSERT_EQ(p.nodes()[mn].children.size(), 1u);
+    EXPECT_EQ(m.get_string(p.nodes()[p.nodes()[mn].children[0]].name_idx), "foo");
+}
+
+TEST(FlameGraph, RangeClampingPartialOverlap) {
+    auto m = make_model();
+    ViewState v;
+    v.has_range_selection = true;
+    v.range_start_ts = 30;
+    v.range_end_ts = 80;
+
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+    size_t mn = p.nodes()[p.root()].children[0];
+
+    // main clamped to [30,80) = 50
+    EXPECT_DOUBLE_EQ(p.nodes()[mn].total_time, 50.0);
+    // foo [10,50) clamped to [30,50) = 20, bar [60,90) clamped to [60,80) = 20
+    auto& foo = find(p, m, "foo", mn);
+    auto& bar = find(p, m, "bar", mn);
+    EXPECT_DOUBLE_EQ(foo.total_time, 20.0);
+    EXPECT_DOUBLE_EQ(bar.total_time, 20.0);
+    // self = 50 - 40 = 10
+    EXPECT_DOUBLE_EQ(p.nodes()[mn].self_time, 10.0);
+}
+
+TEST(FlameGraph, HiddenProcessFiltered) {
+    auto m = make_model();
+    ViewState v;
+    v.hidden_pids.insert(1);
+
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+    EXPECT_TRUE(p.nodes()[p.root()].children.empty());
+}
+
+TEST(FlameGraph, HiddenCategoryFiltered) {
+    auto m = make_model();
+    ViewState v;
+    v.hidden_cats.insert(m.string_map_["test"]);
+
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+    EXPECT_TRUE(p.nodes()[p.root()].children.empty());
+}
+
+TEST(FlameGraph, DifferentCategoriesSeparated) {
+    TraceModel m;
+    uint32_t nf = m.intern_string("foo");
+    uint32_t c1 = m.intern_string("render"), c2 = m.intern_string("net");
+    auto& t = m.get_or_create_process(1).get_or_create_thread(1);
+
+    auto push = [&](uint32_t cat, double ts, double dur) {
+        TraceEvent e;
+        e.name_idx = nf;
+        e.cat_idx = cat;
+        e.ph = Phase::Complete;
+        e.ts = ts;
+        e.dur = dur;
+        e.pid = 1;
+        e.tid = 1;
+        e.parent_idx = -1;
+        e.self_time = dur;
+        uint32_t idx = (uint32_t)m.events_.size();
+        m.events_.push_back(e);
+        t.event_indices.push_back(idx);
+    };
+    push(c1, 0, 50);
+    push(c2, 60, 30);
+
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    auto& nodes = p.nodes();
+    ASSERT_EQ(nodes[p.root()].children.size(), 2u);
+    EXPECT_NE(nodes[nodes[p.root()].children[0]].cat_idx, nodes[nodes[p.root()].children[1]].cat_idx);
+}
+
+TEST(FlameGraph, SelfTimeInteriorNode) {
+    TraceModel m;
+    uint32_t na = m.intern_string("A"), nb = m.intern_string("B"), cat = m.intern_string("c");
+    auto& t = m.get_or_create_process(1).get_or_create_thread(1);
+
+    TraceEvent ea;
+    ea.name_idx = na;
+    ea.cat_idx = cat;
+    ea.ph = Phase::Complete;
+    ea.ts = 0;
+    ea.dur = 100;
+    ea.pid = 1;
+    ea.tid = 1;
+    ea.parent_idx = -1;
+    ea.self_time = 70;
+    m.events_.push_back(ea);
+    t.event_indices.push_back(0);
+
+    TraceEvent eb;
+    eb.name_idx = nb;
+    eb.cat_idx = cat;
+    eb.ph = Phase::Complete;
+    eb.ts = 20;
+    eb.dur = 30;
+    eb.pid = 1;
+    eb.tid = 1;
+    eb.depth = 1;
+    eb.parent_idx = 0;
+    eb.self_time = 30;
+    m.events_.push_back(eb);
+    t.event_indices.push_back(1);
+
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    size_t an = p.nodes()[p.root()].children[0];
+    EXPECT_DOUBLE_EQ(p.nodes()[an].total_time, 100.0);
+    EXPECT_DOUBLE_EQ(p.nodes()[an].self_time, 70.0);
+    size_t bn = p.nodes()[an].children[0];
+    EXPECT_DOUBLE_EQ(p.nodes()[bn].total_time, 30.0);
+    EXPECT_DOUBLE_EQ(p.nodes()[bn].self_time, 30.0);
+}
+
+TEST(FlameGraph, DurationBeginEvents) {
+    TraceModel m;
+    uint32_t nw = m.intern_string("work"), cat = m.intern_string("c");
+    auto& t = m.get_or_create_process(1).get_or_create_thread(1);
+
+    TraceEvent eb;
+    eb.name_idx = nw;
+    eb.cat_idx = cat;
+    eb.ph = Phase::DurationBegin;
+    eb.ts = 10;
+    eb.dur = 40;
+    eb.pid = 1;
+    eb.tid = 1;
+    eb.parent_idx = -1;
+    eb.self_time = 40;
+    m.events_.push_back(eb);
+    t.event_indices.push_back(0);
+
+    TraceEvent ee;
+    ee.name_idx = nw;
+    ee.cat_idx = cat;
+    ee.ph = Phase::DurationEnd;
+    ee.ts = 50;
+    ee.pid = 1;
+    ee.tid = 1;
+    ee.parent_idx = -1;
+    ee.is_end_event = true;
+    m.events_.push_back(ee);
+    t.event_indices.push_back(1);
+
+    ViewState v;
+    FlameGraphPanel p;
+    p.rebuild(m, v);
+
+    ASSERT_EQ(p.nodes()[p.root()].children.size(), 1u);
+    auto& w = p.nodes()[p.nodes()[p.root()].children[0]];
+    EXPECT_DOUBLE_EQ(w.total_time, 40.0);
+    EXPECT_EQ(w.call_count, 1u);
+}


### PR DESCRIPTION
## Summary
- Adds a **Flame Graph** panel that aggregates all call stacks by (name, category) into horizontal bars proportional to total time
- Supports click-to-zoom drill-down, icicle (top-down) toggle, range selection filtering with partial-overlap clamping, and respects process/thread/category visibility filters
- Adds `filter_generation` counter to `ViewState` so panels can detect filter changes without comparing sets; `FilterPanel` bumps it on every mutation

## Test plan
- [x] 11 unit tests covering tree structure, time aggregation, cross-thread merging, range exclusion, range clamping (partial overlap), hidden process/category filtering, category separation, self-time for interior nodes, and B/E-style duration events
- [ ] Manual: load a Chrome trace, verify flame graph renders with correct proportions
- [ ] Manual: toggle filters in Filters panel, verify flame graph rebuilds
- [ ] Manual: select a time range on the ruler, verify flame graph updates to show only that range
- [ ] Manual: click a bar to zoom in, verify zoom out/reset buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)