### PR TITLE
Scroll to selection when switching to Source tab

### DIFF
--- a/src/ui/source_panel.cpp
+++ b/src/ui/source_panel.cpp
@@ -233,6 +233,7 @@ void SourcePanel::render(const TraceModel& model, ViewState& view) {
     }
 
     bool selection_changed = (cached_event_idx_ != view.selected_event_idx());
+    bool tab_just_shown = ImGui::IsWindowAppearing();
 
     // Check if selection or path settings changed
     if (selection_changed) {
@@ -262,6 +263,8 @@ void SourcePanel::render(const TraceModel& model, ViewState& view) {
         path_settings_changed_ = false;
         cached_file_.clear();  // force reload
         resolve_and_load(cached_raw_file_);
+        need_scroll_ = true;
+    } else if (tab_just_shown && cached_line_ > 0) {
         need_scroll_ = true;
     }
 


### PR DESCRIPTION
## Summary
- When switching to the Source tab (or when it first appears), automatically scroll to the highlighted source line
- Uses `ImGui::IsWindowAppearing()` to detect tab visibility changes and re-trigger the existing scroll-to-line logic

## Test plan
- [x] Select an event with source location info
- [x] Switch away from the Source tab, then switch back — verify it scrolls to the highlighted line
- [x] Verify normal selection-change scrolling still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)