### PR TITLE
Details panel: show max depth alongside event depth

### DIFF
--- a/src/ui/detail_panel.cpp
+++ b/src/ui/detail_panel.cpp
@@ -292,7 +292,11 @@ void DetailPanel::render(const TraceModel& model, ViewState& view) {
         ImGui::Text("ID: 0x%llx", (unsigned long long)ev.id);
     }
 
-    ImGui::Text("Depth: %d", ev.depth);
+    if (const auto* th = model.find_thread(ev.pid, ev.tid)) {
+        ImGui::Text("Depth: %d / %d", ev.depth, th->max_depth);
+    } else {
+        ImGui::Text("Depth: %d", ev.depth);
+    }
 
     // Parent button
     if (ev.depth > 0) {


### PR DESCRIPTION
## Summary
- Display `Depth: X / Y` instead of `Depth: X` in the details panel, where Y is the thread's max depth
- Gives immediate context for how deeply nested an event is relative to its thread

Closes #30

## Test plan
- [x] Existing tests pass
- [x] Open a trace and select events at various depths — verify the format shows `Depth: X / Y`
- [x] Verify Y matches the deepest event in that thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)