### PR TITLE
Add verbose self-tracing to all functions in src/

### DIFF
--- a/src/INDEX.md
+++ b/src/INDEX.md
@@ -19,6 +19,8 @@ static Tracer& instance();
 void set_output(const std::string& path);
 void close();
 bool enabled() const;
+void set_verbose(bool v);
+bool verbose() const;
 void write_complete(const char* name, const char* cat, uint64_t ts_us, uint64_t dur_us, const char* args_json = nullptr);
 void write_counter(const char* name, const char* cat, uint64_t ts_us, const char* key, double value);
 uint64_t now_us() const;
@@ -28,4 +30,6 @@ TRACE_SCOPE_CAT(name, cat)
 TRACE_SCOPE_ARGS(name, cat, ...)
 TRACE_FUNCTION()
 TRACE_FUNCTION_CAT(cat)
+TRACE_VERBOSE_SCOPE_CAT(name, cat)
+TRACE_VERBOSE_FUNCTION_CAT(cat)
 ```

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -29,12 +29,14 @@ void App::shutdown() {
 }
 
 void App::open_file(const std::string& path) {
+    TRACE_FUNCTION_CAT("app");
     if (loader_.is_loading()) return;
     loader_.load_file(path, view_.time_unit_ns(), &query_db_);
     status_message_ = "Loading: " + loader_.filename();
 }
 
 void App::open_buffer(std::vector<char> data, const std::string& filename) {
+    TRACE_FUNCTION_CAT("app");
     if (loader_.is_loading()) return;
     loader_.load_buffer(std::move(data), filename, view_.time_unit_ns(), &query_db_);
     status_message_ = "Loading: " + loader_.filename();
@@ -499,6 +501,7 @@ void App::render_settings_modal() {
 }
 
 void App::reset_general_defaults() {
+    TRACE_FUNCTION_CAT("app");
     ImGui::GetIO().FontGlobalScale = 1.0f;
     dark_theme_ = true;
     ImGui::StyleColorsDark();
@@ -508,6 +511,7 @@ void App::reset_general_defaults() {
 }
 
 void App::reset_all_defaults() {
+    TRACE_FUNCTION_CAT("app");
     reset_general_defaults();
     view_.reset_layout_defaults();
     view_.reset_rendering_defaults();

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -29,14 +29,14 @@ void App::shutdown() {
 }
 
 void App::open_file(const std::string& path) {
-    TRACE_FUNCTION_CAT("app");
+    TRACE_VERBOSE_FUNCTION_CAT("app");
     if (loader_.is_loading()) return;
     loader_.load_file(path, view_.time_unit_ns(), &query_db_);
     status_message_ = "Loading: " + loader_.filename();
 }
 
 void App::open_buffer(std::vector<char> data, const std::string& filename) {
-    TRACE_FUNCTION_CAT("app");
+    TRACE_VERBOSE_FUNCTION_CAT("app");
     if (loader_.is_loading()) return;
     loader_.load_buffer(std::move(data), filename, view_.time_unit_ns(), &query_db_);
     status_message_ = "Loading: " + loader_.filename();
@@ -501,7 +501,7 @@ void App::render_settings_modal() {
 }
 
 void App::reset_general_defaults() {
-    TRACE_FUNCTION_CAT("app");
+    TRACE_VERBOSE_FUNCTION_CAT("app");
     ImGui::GetIO().FontGlobalScale = 1.0f;
     dark_theme_ = true;
     ImGui::StyleColorsDark();
@@ -511,7 +511,7 @@ void App::reset_general_defaults() {
 }
 
 void App::reset_all_defaults() {
-    TRACE_FUNCTION_CAT("app");
+    TRACE_VERBOSE_FUNCTION_CAT("app");
     reset_general_defaults();
     view_.reset_layout_defaults();
     view_.reset_rendering_defaults();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,7 @@ int main(int argc, char* argv[]) {
     // Parse command-line arguments
     const char* file_arg = nullptr;
     const char* trace_output = nullptr;
+    bool verbose_trace = false;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-ns") == 0) {
             app.set_time_unit_ns(true);
@@ -134,6 +135,8 @@ int main(int argc, char* argv[]) {
             app.set_time_unit_ns(false);
         } else if (strcmp(argv[i], "--trace") == 0 && i + 1 < argc) {
             trace_output = argv[++i];
+        } else if (strcmp(argv[i], "--verbose-trace") == 0) {
+            verbose_trace = true;
         } else {
             file_arg = argv[i];
         }
@@ -141,7 +144,12 @@ int main(int argc, char* argv[]) {
 
     if (trace_output) {
         Tracer::instance().set_output(trace_output);
-        printf("Tracing to: %s\n", trace_output);
+        if (verbose_trace) {
+            Tracer::instance().set_verbose(true);
+            printf("Verbose tracing to: %s\n", trace_output);
+        } else {
+            printf("Tracing to: %s\n", trace_output);
+        }
     }
 
     if (file_arg) {

--- a/src/model/query_db.cpp
+++ b/src/model/query_db.cpp
@@ -230,7 +230,7 @@ QueryDb::QueryResult QueryDb::execute(const std::string& sql) {
 }
 
 int QueryDb::progress_callback(void* data) {
-    TRACE_FUNCTION_CAT("model");
+    TRACE_VERBOSE_FUNCTION_CAT("model");
     auto* self = static_cast<QueryDb*>(data);
     self->query_steps_.fetch_add(1000, std::memory_order_relaxed);
     // Return non-zero to cancel

--- a/src/model/query_db.cpp
+++ b/src/model/query_db.cpp
@@ -230,6 +230,7 @@ QueryDb::QueryResult QueryDb::execute(const std::string& sql) {
 }
 
 int QueryDb::progress_callback(void* data) {
+    TRACE_FUNCTION_CAT("model");
     auto* self = static_cast<QueryDb*>(data);
     self->query_steps_.fetch_add(1000, std::memory_order_relaxed);
     // Return non-zero to cancel

--- a/src/model/trace_model.cpp
+++ b/src/model/trace_model.cpp
@@ -255,6 +255,7 @@ double TraceModel::compute_self_time(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_longest_child(uint32_t event_idx) const {
+    TRACE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);
@@ -277,6 +278,7 @@ int32_t TraceModel::find_longest_child(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_prev_sibling(uint32_t event_idx) const {
+    TRACE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);
@@ -293,6 +295,7 @@ int32_t TraceModel::find_prev_sibling(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_next_sibling(uint32_t event_idx) const {
+    TRACE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);

--- a/src/model/trace_model.cpp
+++ b/src/model/trace_model.cpp
@@ -255,7 +255,7 @@ double TraceModel::compute_self_time(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_longest_child(uint32_t event_idx) const {
-    TRACE_FUNCTION_CAT("model");
+    TRACE_VERBOSE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);
@@ -278,7 +278,7 @@ int32_t TraceModel::find_longest_child(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_prev_sibling(uint32_t event_idx) const {
-    TRACE_FUNCTION_CAT("model");
+    TRACE_VERBOSE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);
@@ -295,7 +295,7 @@ int32_t TraceModel::find_prev_sibling(uint32_t event_idx) const {
 }
 
 int32_t TraceModel::find_next_sibling(uint32_t event_idx) const {
-    TRACE_FUNCTION_CAT("model");
+    TRACE_VERBOSE_FUNCTION_CAT("model");
     if (event_idx >= events_.size()) return -1;
     const auto& ev = events_[event_idx];
     const auto* thread = find_thread(ev.pid, ev.tid);

--- a/src/parser/trace_parser.cpp
+++ b/src/parser/trace_parser.cpp
@@ -41,6 +41,7 @@ struct SaxHandler : json::json_sax_t {
     SaxHandler(TraceModel& m, std::function<void(const char*, float)>& prog) : model(m), on_progress(prog) {}
 
     void finish_event() {
+        TRACE_FUNCTION_CAT("io");
         event_count++;
         if (on_progress && (event_count & 0xFFFF) == 0 && estimated_events > 0) {
             float p = std::min(0.99f, (float)event_count / (float)estimated_events);
@@ -95,6 +96,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     void handle_metadata() {
+        TRACE_FUNCTION_CAT("io");
         const std::string& name = model.get_string(current_event.name_idx);
         auto& proc = model.get_or_create_process(current_event.pid);
 
@@ -177,6 +179,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     bool handle_number(double val, const std::string& raw) {
+        TRACE_FUNCTION_CAT("io");
         if (state == State::InArgs) {
             if (args_depth == 0) {
                 // Top-level arg value - for counter events, capture the value
@@ -382,6 +385,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     static std::string escape_json_string(const std::string& s) {
+        TRACE_FUNCTION_CAT("io");
         std::string result;
         result.reserve(s.size());
         for (char c : s) {

--- a/src/parser/trace_parser.cpp
+++ b/src/parser/trace_parser.cpp
@@ -41,7 +41,7 @@ struct SaxHandler : json::json_sax_t {
     SaxHandler(TraceModel& m, std::function<void(const char*, float)>& prog) : model(m), on_progress(prog) {}
 
     void finish_event() {
-        TRACE_FUNCTION_CAT("io");
+        TRACE_VERBOSE_FUNCTION_CAT("io");
         event_count++;
         if (on_progress && (event_count & 0xFFFF) == 0 && estimated_events > 0) {
             float p = std::min(0.99f, (float)event_count / (float)estimated_events);
@@ -96,7 +96,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     void handle_metadata() {
-        TRACE_FUNCTION_CAT("io");
+        TRACE_VERBOSE_FUNCTION_CAT("io");
         const std::string& name = model.get_string(current_event.name_idx);
         auto& proc = model.get_or_create_process(current_event.pid);
 
@@ -179,7 +179,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     bool handle_number(double val, const std::string& raw) {
-        TRACE_FUNCTION_CAT("io");
+        TRACE_VERBOSE_FUNCTION_CAT("io");
         if (state == State::InArgs) {
             if (args_depth == 0) {
                 // Top-level arg value - for counter events, capture the value
@@ -385,7 +385,7 @@ struct SaxHandler : json::json_sax_t {
     }
 
     static std::string escape_json_string(const std::string& s) {
-        TRACE_FUNCTION_CAT("io");
+        TRACE_VERBOSE_FUNCTION_CAT("io");
         std::string result;
         result.reserve(s.size());
         for (char c : s) {

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -144,6 +144,9 @@ public:
         }
     }
 
+    void set_verbose(bool v) { verbose_ = v; }
+    bool verbose() const { return verbose_; }
+
     void close() {
         std::lock_guard<std::mutex> lock(mutex_);
         close_file();
@@ -221,6 +224,7 @@ private:
     FILE* file_ = nullptr;
     bool first_event_ = true;
     bool enabled_ = false;
+    bool verbose_ = false;
     std::mutex mutex_;
     std::chrono::steady_clock::time_point epoch_;
 };
@@ -228,9 +232,10 @@ private:
 // RAII scope tracer — always emits file/line/func as args
 class TraceScope {
 public:
-    TraceScope(const char* name, const char* cat, const char* file, int line, const char* func)
+    TraceScope(const char* name, const char* cat, const char* file, int line, const char* func,
+               bool verbose_only = false)
         : name_(name), cat_(cat), file_(file), line_(line), func_(func) {
-        if (Tracer::instance().enabled()) {
+        if (Tracer::instance().enabled() && (!verbose_only || Tracer::instance().verbose())) {
             start_ = Tracer::instance().now_us();
             active_ = true;
         }
@@ -303,3 +308,9 @@ private:
 #define TRACE_FUNCTION() TraceScope _trace_scope_##__LINE__(TRACE_FUNC_SIG, "app", __FILE__, __LINE__, TRACE_FUNC_SIG)
 #define TRACE_FUNCTION_CAT(cat) \
     TraceScope _trace_scope_##__LINE__(TRACE_FUNC_SIG, cat, __FILE__, __LINE__, TRACE_FUNC_SIG)
+
+// Verbose variants — only emit when --verbose-trace is enabled
+#define TRACE_VERBOSE_SCOPE_CAT(name, cat) \
+    TraceScope _trace_scope_##__LINE__(name, cat, __FILE__, __LINE__, TRACE_FUNC_SIG, true)
+#define TRACE_VERBOSE_FUNCTION_CAT(cat) \
+    TraceScope _trace_scope_##__LINE__(TRACE_FUNC_SIG, cat, __FILE__, __LINE__, TRACE_FUNC_SIG, true)

--- a/src/ui/counter_track.cpp
+++ b/src/ui/counter_track.cpp
@@ -51,7 +51,7 @@ static float time_to_x(double ts, double view_start, double view_end, float trac
 std::vector<MergedCounterSegment> merge_counter_points(const std::vector<std::pair<double, double>>& points,
                                                        double view_start, double view_end, float track_x,
                                                        float track_w) {
-    TRACE_FUNCTION_CAT("timeline");
+    TRACE_VERBOSE_FUNCTION_CAT("timeline");
     std::vector<MergedCounterSegment> result;
     if (points.empty()) return result;
 
@@ -161,7 +161,7 @@ void CounterTrackRenderer::render_series(ImDrawList* dl, ImVec2 track_min, ImVec
 }
 
 bool counter_lookup_value(const CounterSeries& series, double time, double& out_timestamp, double& out_value) {
-    TRACE_FUNCTION_CAT("timeline");
+    TRACE_VERBOSE_FUNCTION_CAT("timeline");
     if (series.points.empty()) return false;
 
     auto it = std::upper_bound(series.points.begin(), series.points.end(), time,
@@ -178,7 +178,7 @@ bool counter_lookup_value(const CounterSeries& series, double time, double& out_
 
 bool CounterTrackRenderer::hit_test(float mouse_x, float mouse_y, const ViewState& view,
                                     CounterHitResult& result) const {
-    TRACE_FUNCTION_CAT("timeline");
+    TRACE_VERBOSE_FUNCTION_CAT("timeline");
     for (const auto& layout : layouts_) {
         if (mouse_y < layout.track_min.y || mouse_y >= layout.track_max.y) continue;
         if (mouse_x < layout.track_min.x || mouse_x >= layout.track_max.x) continue;

--- a/src/ui/counter_track.cpp
+++ b/src/ui/counter_track.cpp
@@ -51,6 +51,7 @@ static float time_to_x(double ts, double view_start, double view_end, float trac
 std::vector<MergedCounterSegment> merge_counter_points(const std::vector<std::pair<double, double>>& points,
                                                        double view_start, double view_end, float track_x,
                                                        float track_w) {
+    TRACE_FUNCTION_CAT("timeline");
     std::vector<MergedCounterSegment> result;
     if (points.empty()) return result;
 
@@ -160,6 +161,7 @@ void CounterTrackRenderer::render_series(ImDrawList* dl, ImVec2 track_min, ImVec
 }
 
 bool counter_lookup_value(const CounterSeries& series, double time, double& out_timestamp, double& out_value) {
+    TRACE_FUNCTION_CAT("timeline");
     if (series.points.empty()) return false;
 
     auto it = std::upper_bound(series.points.begin(), series.points.end(), time,
@@ -176,6 +178,7 @@ bool counter_lookup_value(const CounterSeries& series, double time, double& out_
 
 bool CounterTrackRenderer::hit_test(float mouse_x, float mouse_y, const ViewState& view,
                                     CounterHitResult& result) const {
+    TRACE_FUNCTION_CAT("timeline");
     for (const auto& layout : layouts_) {
         if (mouse_y < layout.track_min.y || mouse_y >= layout.track_max.y) continue;
         if (mouse_x < layout.track_min.x || mouse_x >= layout.track_max.x) continue;

--- a/src/ui/detail_panel.cpp
+++ b/src/ui/detail_panel.cpp
@@ -13,7 +13,7 @@
 #include <unordered_map>
 
 void DetailPanel::reset() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     cached_range_start_ = 0.0;
     cached_range_end_ = 0.0;
     range_stats_ = {};
@@ -46,7 +46,7 @@ void DetailPanel::on_model_changed() {
 
 // Returns a color interpolated from blue (cool, 0%) through green/yellow to red (hot, 100%)
 static ImVec4 heat_color(float pct) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     float t = std::min(std::max(pct / 100.0f, 0.0f), 1.0f);
     // Blue -> Cyan -> Green -> Yellow -> Red
     float r, g, b;
@@ -75,7 +75,7 @@ static ImVec4 heat_color(float pct) {
 }
 
 static void render_heat_bar(float pct) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     ImVec4 col = heat_color(pct);
     ImGui::PushStyleColor(ImGuiCol_PlotHistogram, col);
     ImGui::ProgressBar(pct / 100.0f, ImVec2(-1, 0), "");
@@ -117,7 +117,7 @@ static const char* phase_name(Phase ph) {
 }
 
 static void render_json_value(const nlohmann::json& j, int depth = 0) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (j.is_object()) {
         for (auto& [key, val] : j.items()) {
             if (val.is_object() || val.is_array()) {

--- a/src/ui/detail_panel.cpp
+++ b/src/ui/detail_panel.cpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 
 void DetailPanel::reset() {
+    TRACE_FUNCTION_CAT("ui");
     cached_range_start_ = 0.0;
     cached_range_end_ = 0.0;
     range_stats_ = {};
@@ -45,6 +46,7 @@ void DetailPanel::on_model_changed() {
 
 // Returns a color interpolated from blue (cool, 0%) through green/yellow to red (hot, 100%)
 static ImVec4 heat_color(float pct) {
+    TRACE_FUNCTION_CAT("ui");
     float t = std::min(std::max(pct / 100.0f, 0.0f), 1.0f);
     // Blue -> Cyan -> Green -> Yellow -> Red
     float r, g, b;
@@ -73,6 +75,7 @@ static ImVec4 heat_color(float pct) {
 }
 
 static void render_heat_bar(float pct) {
+    TRACE_FUNCTION_CAT("ui");
     ImVec4 col = heat_color(pct);
     ImGui::PushStyleColor(ImGuiCol_PlotHistogram, col);
     ImGui::ProgressBar(pct / 100.0f, ImVec2(-1, 0), "");
@@ -114,6 +117,7 @@ static const char* phase_name(Phase ph) {
 }
 
 static void render_json_value(const nlohmann::json& j, int depth = 0) {
+    TRACE_FUNCTION_CAT("ui");
     if (j.is_object()) {
         for (auto& [key, val] : j.items()) {
             if (val.is_object() || val.is_array()) {

--- a/src/ui/diagnostics_panel.cpp
+++ b/src/ui/diagnostics_panel.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 
 static void format_bytes(size_t bytes, char* buf, size_t buf_size) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (bytes >= 1024ULL * 1024 * 1024)
         snprintf(buf, buf_size, "%.1f GB", bytes / (1024.0 * 1024 * 1024));
     else if (bytes >= 1024ULL * 1024)

--- a/src/ui/diagnostics_panel.cpp
+++ b/src/ui/diagnostics_panel.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 
 static void format_bytes(size_t bytes, char* buf, size_t buf_size) {
+    TRACE_FUNCTION_CAT("ui");
     if (bytes >= 1024ULL * 1024 * 1024)
         snprintf(buf, buf_size, "%.1f GB", bytes / (1024.0 * 1024 * 1024));
     else if (bytes >= 1024ULL * 1024)

--- a/src/ui/flame_graph_panel.cpp
+++ b/src/ui/flame_graph_panel.cpp
@@ -2,11 +2,13 @@
 #include "ui/format_time.h"
 #include "ui/string_utils.h"
 #include "model/color_palette.h"
+#include "tracing.h"
 #include "imgui.h"
 #include <algorithm>
 #include <cstdio>
 
 void FlameGraphPanel::reset() {
+    TRACE_FUNCTION_CAT("ui");
     trees_.clear();
     cached_event_count_ = 0;
     cached_has_range_ = false;
@@ -25,6 +27,7 @@ void FlameGraphPanel::on_model_changed() {
 }
 
 int32_t FlameGraphPanel::find_longest_instance(const TraceModel& model, uint32_t pid, uint32_t tid, uint32_t name_idx) {
+    TRACE_FUNCTION_CAT("ui");
     const auto* thread = model.find_thread(pid, tid);
     if (!thread) return -1;
     int32_t best = -1;
@@ -44,6 +47,7 @@ int32_t FlameGraphPanel::find_longest_instance(const TraceModel& model, uint32_t
 // ---------------------------------------------------------------------------
 
 size_t FlameGraphPanel::compute_hidden_hash(const ViewState& view) const {
+    TRACE_FUNCTION_CAT("ui");
     size_t h = view.hidden_pids().size() * 31 + view.hidden_tids().size() * 37 + view.hidden_cats().size() * 41;
     for (uint32_t v : view.hidden_pids()) h ^= std::hash<uint32_t>{}(v) * 0x9e3779b97f4a7c15ULL;
     for (uint32_t v : view.hidden_tids()) h ^= std::hash<uint32_t>{}(v) * 0x517cc1b727220a95ULL;
@@ -52,6 +56,7 @@ size_t FlameGraphPanel::compute_hidden_hash(const ViewState& view) const {
 }
 
 bool FlameGraphPanel::needs_rebuild(const ViewState& view, size_t event_count) const {
+    TRACE_FUNCTION_CAT("ui");
     if (cached_event_count_ != event_count) return true;
     if (cached_has_range_ != view.has_range_selection()) return true;
     if (view.has_range_selection()) {
@@ -62,6 +67,7 @@ bool FlameGraphPanel::needs_rebuild(const ViewState& view, size_t event_count) c
 }
 
 void FlameGraphPanel::update_cache_keys(const ViewState& view, size_t event_count) {
+    TRACE_FUNCTION_CAT("ui");
     cached_event_count_ = event_count;
     cached_has_range_ = view.has_range_selection();
     cached_range_start_ = view.range_start_ts();
@@ -75,6 +81,7 @@ void FlameGraphPanel::update_cache_keys(const ViewState& view, size_t event_coun
 
 uint32_t FlameGraphPanel::find_or_create_child(FlameTree& tree, uint32_t parent_idx, uint32_t name_idx,
                                                uint32_t cat_idx) {
+    TRACE_FUNCTION_CAT("ui");
     for (uint32_t c = tree.nodes[parent_idx].first_child; c != UINT32_MAX; c = tree.nodes[c].next_sibling) {
         if (tree.nodes[c].name_idx == name_idx && tree.nodes[c].cat_idx == cat_idx) return c;
     }
@@ -90,6 +97,7 @@ uint32_t FlameGraphPanel::find_or_create_child(FlameTree& tree, uint32_t parent_
 }
 
 uint32_t FlameGraphPanel::find_or_create_root(FlameTree& tree, uint32_t name_idx, uint32_t cat_idx) {
+    TRACE_FUNCTION_CAT("ui");
     for (uint32_t c = tree.first_root; c != UINT32_MAX; c = tree.nodes[c].next_sibling) {
         if (tree.nodes[c].name_idx == name_idx && tree.nodes[c].cat_idx == cat_idx) return c;
     }
@@ -104,6 +112,7 @@ uint32_t FlameGraphPanel::find_or_create_root(FlameTree& tree, uint32_t name_idx
 }
 
 uint32_t FlameGraphPanel::sort_children(FlameTree& tree, uint32_t first_child) {
+    TRACE_FUNCTION_CAT("ui");
     if (first_child == UINT32_MAX) return UINT32_MAX;
 
     // Collect child indices, sort by total_time descending, re-link.
@@ -123,6 +132,7 @@ uint32_t FlameGraphPanel::sort_children(FlameTree& tree, uint32_t first_child) {
 }
 
 void FlameGraphPanel::compute_self_times(FlameTree& tree) {
+    TRACE_FUNCTION_CAT("ui");
     // Reverse iteration: children are always appended after parents in the pool,
     // so processing in reverse guarantees children are resolved before parents.
     for (int i = (int)tree.nodes.size() - 1; i >= 0; --i) {
@@ -140,6 +150,7 @@ void FlameGraphPanel::compute_self_times(FlameTree& tree) {
 }
 
 void FlameGraphPanel::rebuild(const TraceModel& model, const ViewState& view) {
+    TRACE_FUNCTION_CAT("ui");
     trees_.clear();
 
     bool has_range = view.has_range_selection();
@@ -229,6 +240,7 @@ void FlameGraphPanel::rebuild(const TraceModel& model, const ViewState& view) {
 // ---------------------------------------------------------------------------
 
 void FlameGraphPanel::render(const TraceModel& model, ViewState& view) {
+    TRACE_SCOPE_CAT("FlameGraph", "ui");
     ImGui::Begin("Flame Graph");
 
     if (model.events().empty()) {
@@ -311,6 +323,7 @@ void FlameGraphPanel::render(const TraceModel& model, ViewState& view) {
 }
 
 void FlameGraphPanel::render_icicle(const TraceModel& model, ViewState& view, int tree_idx) {
+    TRACE_FUNCTION_CAT("ui");
     const auto& tree = trees_[tree_idx];
     uint32_t zoom = zoom_root_[tree_idx];
     bool zoomed = (zoom != UINT32_MAX);

--- a/src/ui/flame_graph_panel.cpp
+++ b/src/ui/flame_graph_panel.cpp
@@ -8,7 +8,7 @@
 #include <cstdio>
 
 void FlameGraphPanel::reset() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     trees_.clear();
     cached_event_count_ = 0;
     cached_has_range_ = false;
@@ -27,7 +27,7 @@ void FlameGraphPanel::on_model_changed() {
 }
 
 int32_t FlameGraphPanel::find_longest_instance(const TraceModel& model, uint32_t pid, uint32_t tid, uint32_t name_idx) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     const auto* thread = model.find_thread(pid, tid);
     if (!thread) return -1;
     int32_t best = -1;
@@ -47,7 +47,7 @@ int32_t FlameGraphPanel::find_longest_instance(const TraceModel& model, uint32_t
 // ---------------------------------------------------------------------------
 
 size_t FlameGraphPanel::compute_hidden_hash(const ViewState& view) const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     size_t h = view.hidden_pids().size() * 31 + view.hidden_tids().size() * 37 + view.hidden_cats().size() * 41;
     for (uint32_t v : view.hidden_pids()) h ^= std::hash<uint32_t>{}(v) * 0x9e3779b97f4a7c15ULL;
     for (uint32_t v : view.hidden_tids()) h ^= std::hash<uint32_t>{}(v) * 0x517cc1b727220a95ULL;
@@ -56,7 +56,7 @@ size_t FlameGraphPanel::compute_hidden_hash(const ViewState& view) const {
 }
 
 bool FlameGraphPanel::needs_rebuild(const ViewState& view, size_t event_count) const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (cached_event_count_ != event_count) return true;
     if (cached_has_range_ != view.has_range_selection()) return true;
     if (view.has_range_selection()) {
@@ -67,7 +67,7 @@ bool FlameGraphPanel::needs_rebuild(const ViewState& view, size_t event_count) c
 }
 
 void FlameGraphPanel::update_cache_keys(const ViewState& view, size_t event_count) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     cached_event_count_ = event_count;
     cached_has_range_ = view.has_range_selection();
     cached_range_start_ = view.range_start_ts();
@@ -81,7 +81,7 @@ void FlameGraphPanel::update_cache_keys(const ViewState& view, size_t event_coun
 
 uint32_t FlameGraphPanel::find_or_create_child(FlameTree& tree, uint32_t parent_idx, uint32_t name_idx,
                                                uint32_t cat_idx) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     for (uint32_t c = tree.nodes[parent_idx].first_child; c != UINT32_MAX; c = tree.nodes[c].next_sibling) {
         if (tree.nodes[c].name_idx == name_idx && tree.nodes[c].cat_idx == cat_idx) return c;
     }
@@ -97,7 +97,7 @@ uint32_t FlameGraphPanel::find_or_create_child(FlameTree& tree, uint32_t parent_
 }
 
 uint32_t FlameGraphPanel::find_or_create_root(FlameTree& tree, uint32_t name_idx, uint32_t cat_idx) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     for (uint32_t c = tree.first_root; c != UINT32_MAX; c = tree.nodes[c].next_sibling) {
         if (tree.nodes[c].name_idx == name_idx && tree.nodes[c].cat_idx == cat_idx) return c;
     }
@@ -112,7 +112,7 @@ uint32_t FlameGraphPanel::find_or_create_root(FlameTree& tree, uint32_t name_idx
 }
 
 uint32_t FlameGraphPanel::sort_children(FlameTree& tree, uint32_t first_child) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (first_child == UINT32_MAX) return UINT32_MAX;
 
     // Collect child indices, sort by total_time descending, re-link.
@@ -132,7 +132,7 @@ uint32_t FlameGraphPanel::sort_children(FlameTree& tree, uint32_t first_child) {
 }
 
 void FlameGraphPanel::compute_self_times(FlameTree& tree) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     // Reverse iteration: children are always appended after parents in the pool,
     // so processing in reverse guarantees children are resolved before parents.
     for (int i = (int)tree.nodes.size() - 1; i >= 0; --i) {
@@ -150,7 +150,7 @@ void FlameGraphPanel::compute_self_times(FlameTree& tree) {
 }
 
 void FlameGraphPanel::rebuild(const TraceModel& model, const ViewState& view) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     trees_.clear();
 
     bool has_range = view.has_range_selection();
@@ -240,7 +240,7 @@ void FlameGraphPanel::rebuild(const TraceModel& model, const ViewState& view) {
 // ---------------------------------------------------------------------------
 
 void FlameGraphPanel::render(const TraceModel& model, ViewState& view) {
-    TRACE_SCOPE_CAT("FlameGraph", "ui");
+    TRACE_VERBOSE_SCOPE_CAT("FlameGraph", "ui");
     ImGui::Begin("Flame Graph");
 
     if (model.events().empty()) {
@@ -323,7 +323,7 @@ void FlameGraphPanel::render(const TraceModel& model, ViewState& view) {
 }
 
 void FlameGraphPanel::render_icicle(const TraceModel& model, ViewState& view, int tree_idx) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     const auto& tree = trees_[tree_idx];
     uint32_t zoom = zoom_root_[tree_idx];
     bool zoomed = (zoom != UINT32_MAX);

--- a/src/ui/instance_panel.cpp
+++ b/src/ui/instance_panel.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 
 void InstancePanel::reset() {
+    TRACE_FUNCTION_CAT("ui");
     selected_name_.clear();
     instances_.clear();
     instance_cursor_ = -1;

--- a/src/ui/instance_panel.cpp
+++ b/src/ui/instance_panel.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 
 void InstancePanel::reset() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     selected_name_.clear();
     instances_.clear();
     instance_cursor_ = -1;

--- a/src/ui/key_bindings.cpp
+++ b/src/ui/key_bindings.cpp
@@ -7,7 +7,7 @@ KeyBindings::KeyBindings() {
 }
 
 void KeyBindings::reset_defaults() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     bindings_[static_cast<int>(Action::PanLeft)] = {ImGuiKey_LeftArrow, ImGuiKey_None};
     bindings_[static_cast<int>(Action::PanRight)] = {ImGuiKey_RightArrow, ImGuiKey_None};
     bindings_[static_cast<int>(Action::ScrollUp)] = {ImGuiKey_UpArrow, ImGuiKey_None};
@@ -28,7 +28,7 @@ void KeyBindings::reset_defaults() {
 }
 
 bool KeyBindings::is_pressed(Action action) const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     int idx = static_cast<int>(action);
     const auto& b = bindings_[idx];
     if (b.primary != ImGuiKey_None && ImGui::IsKeyChordPressed(b.primary)) return true;
@@ -37,7 +37,7 @@ bool KeyBindings::is_pressed(Action action) const {
 }
 
 const char* KeyBindings::action_name(Action action) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     switch (action) {
         case Action::PanLeft:
             return "Pan Left";
@@ -79,7 +79,7 @@ const char* KeyBindings::action_name(Action action) {
 }
 
 std::string KeyBindings::key_chord_name(ImGuiKeyChord chord) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (chord == ImGuiKey_None) return "---";
     std::string result;
     if (chord & ImGuiMod_Ctrl) result += "Ctrl+";
@@ -91,7 +91,7 @@ std::string KeyBindings::key_chord_name(ImGuiKeyChord chord) {
 }
 
 const char* KeyBindings::action_id(Action action) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     switch (action) {
         case Action::PanLeft:
             return "pan_left";
@@ -133,7 +133,7 @@ const char* KeyBindings::action_id(Action action) {
 }
 
 bool KeyBindings::is_modifier_key(ImGuiKey key) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     return key == ImGuiKey_LeftCtrl || key == ImGuiKey_RightCtrl || key == ImGuiKey_LeftShift ||
            key == ImGuiKey_RightShift || key == ImGuiKey_LeftAlt || key == ImGuiKey_RightAlt ||
            key == ImGuiKey_LeftSuper || key == ImGuiKey_RightSuper || key == ImGuiKey_ReservedForModCtrl ||
@@ -142,7 +142,7 @@ bool KeyBindings::is_modifier_key(ImGuiKey key) {
 }
 
 void KeyBindings::clear_conflict(int action_idx, int slot, ImGuiKeyChord chord) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (chord == ImGuiKey_None) return;
     for (int i = 0; i < kCount; i++) {
         if (i == action_idx) continue;
@@ -155,7 +155,7 @@ void KeyBindings::clear_conflict(int action_idx, int slot, ImGuiKeyChord chord) 
 }
 
 void KeyBindings::render_settings() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     ImGui::TextWrapped("Click a binding to change it. Press Escape to cancel, Delete to clear.");
     ImGui::Spacing();
 
@@ -225,7 +225,7 @@ void KeyBindings::render_settings() {
 }
 
 nlohmann::json KeyBindings::save() const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     nlohmann::json j = nlohmann::json::object();
     for (int i = 0; i < kCount; i++) {
         auto action = static_cast<Action>(i);
@@ -236,7 +236,7 @@ nlohmann::json KeyBindings::save() const {
 }
 
 void KeyBindings::load(const nlohmann::json& j) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (!j.is_object()) return;
     for (int i = 0; i < kCount; i++) {
         auto action = static_cast<Action>(i);

--- a/src/ui/key_bindings.cpp
+++ b/src/ui/key_bindings.cpp
@@ -1,4 +1,5 @@
 #include "ui/key_bindings.h"
+#include "tracing.h"
 #include <nlohmann/json.hpp>
 
 KeyBindings::KeyBindings() {
@@ -6,6 +7,7 @@ KeyBindings::KeyBindings() {
 }
 
 void KeyBindings::reset_defaults() {
+    TRACE_FUNCTION_CAT("ui");
     bindings_[static_cast<int>(Action::PanLeft)] = {ImGuiKey_LeftArrow, ImGuiKey_None};
     bindings_[static_cast<int>(Action::PanRight)] = {ImGuiKey_RightArrow, ImGuiKey_None};
     bindings_[static_cast<int>(Action::ScrollUp)] = {ImGuiKey_UpArrow, ImGuiKey_None};
@@ -26,6 +28,7 @@ void KeyBindings::reset_defaults() {
 }
 
 bool KeyBindings::is_pressed(Action action) const {
+    TRACE_FUNCTION_CAT("ui");
     int idx = static_cast<int>(action);
     const auto& b = bindings_[idx];
     if (b.primary != ImGuiKey_None && ImGui::IsKeyChordPressed(b.primary)) return true;
@@ -34,6 +37,7 @@ bool KeyBindings::is_pressed(Action action) const {
 }
 
 const char* KeyBindings::action_name(Action action) {
+    TRACE_FUNCTION_CAT("ui");
     switch (action) {
         case Action::PanLeft:
             return "Pan Left";
@@ -75,6 +79,7 @@ const char* KeyBindings::action_name(Action action) {
 }
 
 std::string KeyBindings::key_chord_name(ImGuiKeyChord chord) {
+    TRACE_FUNCTION_CAT("ui");
     if (chord == ImGuiKey_None) return "---";
     std::string result;
     if (chord & ImGuiMod_Ctrl) result += "Ctrl+";
@@ -86,6 +91,7 @@ std::string KeyBindings::key_chord_name(ImGuiKeyChord chord) {
 }
 
 const char* KeyBindings::action_id(Action action) {
+    TRACE_FUNCTION_CAT("ui");
     switch (action) {
         case Action::PanLeft:
             return "pan_left";
@@ -127,6 +133,7 @@ const char* KeyBindings::action_id(Action action) {
 }
 
 bool KeyBindings::is_modifier_key(ImGuiKey key) {
+    TRACE_FUNCTION_CAT("ui");
     return key == ImGuiKey_LeftCtrl || key == ImGuiKey_RightCtrl || key == ImGuiKey_LeftShift ||
            key == ImGuiKey_RightShift || key == ImGuiKey_LeftAlt || key == ImGuiKey_RightAlt ||
            key == ImGuiKey_LeftSuper || key == ImGuiKey_RightSuper || key == ImGuiKey_ReservedForModCtrl ||
@@ -135,6 +142,7 @@ bool KeyBindings::is_modifier_key(ImGuiKey key) {
 }
 
 void KeyBindings::clear_conflict(int action_idx, int slot, ImGuiKeyChord chord) {
+    TRACE_FUNCTION_CAT("ui");
     if (chord == ImGuiKey_None) return;
     for (int i = 0; i < kCount; i++) {
         if (i == action_idx) continue;
@@ -147,6 +155,7 @@ void KeyBindings::clear_conflict(int action_idx, int slot, ImGuiKeyChord chord) 
 }
 
 void KeyBindings::render_settings() {
+    TRACE_FUNCTION_CAT("ui");
     ImGui::TextWrapped("Click a binding to change it. Press Escape to cancel, Delete to clear.");
     ImGui::Spacing();
 
@@ -216,6 +225,7 @@ void KeyBindings::render_settings() {
 }
 
 nlohmann::json KeyBindings::save() const {
+    TRACE_FUNCTION_CAT("ui");
     nlohmann::json j = nlohmann::json::object();
     for (int i = 0; i < kCount; i++) {
         auto action = static_cast<Action>(i);
@@ -226,6 +236,7 @@ nlohmann::json KeyBindings::save() const {
 }
 
 void KeyBindings::load(const nlohmann::json& j) {
+    TRACE_FUNCTION_CAT("ui");
     if (!j.is_object()) return;
     for (int i = 0; i < kCount; i++) {
         auto action = static_cast<Action>(i);

--- a/src/ui/search_panel.cpp
+++ b/src/ui/search_panel.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 
 void SearchPanel::reset() {
+    TRACE_FUNCTION_CAT("ui");
     search_buf_[0] = '\0';
     needs_search_ = false;
     sorted_results_.clear();

--- a/src/ui/search_panel.cpp
+++ b/src/ui/search_panel.cpp
@@ -8,7 +8,7 @@
 #include <cstdio>
 
 void SearchPanel::reset() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     search_buf_[0] = '\0';
     needs_search_ = false;
     sorted_results_.clear();

--- a/src/ui/source_panel.cpp
+++ b/src/ui/source_panel.cpp
@@ -13,6 +13,7 @@ using json = nlohmann::json;
 
 // Try common field names for source file and line in event args
 bool extract_source_location(const TraceModel& model, const TraceEvent& ev, std::string& file, int& line) {
+    TRACE_FUNCTION_CAT("io");
     if (ev.args_idx == UINT32_MAX || ev.args_idx >= model.args().size()) return false;
 
     try {
@@ -51,6 +52,7 @@ bool extract_source_location(const TraceModel& model, const TraceEvent& ev, std:
 }
 
 static std::string normalize_slashes(const std::string& path) {
+    TRACE_FUNCTION_CAT("io");
     std::string out = path;
     for (auto& c : out) {
         if (c == '\\') c = '/';
@@ -60,6 +62,7 @@ static std::string normalize_slashes(const std::string& path) {
 
 std::string remap_source_path(const std::string& trace_path, const std::string& strip_prefix,
                               const std::string& local_base) {
+    TRACE_FUNCTION_CAT("io");
     std::string path = normalize_slashes(trace_path);
     std::string strip = normalize_slashes(strip_prefix);
     std::string base = normalize_slashes(local_base);
@@ -96,6 +99,7 @@ std::string remap_source_path(const std::string& trace_path, const std::string& 
 }
 
 json SourcePanel::save_settings() const {
+    TRACE_FUNCTION_CAT("ui");
     json j;
     j["strip_prefix"] = strip_prefix_;
     j["local_base"] = local_base_;
@@ -103,6 +107,7 @@ json SourcePanel::save_settings() const {
 }
 
 void SourcePanel::load_settings(const json& j) {
+    TRACE_FUNCTION_CAT("ui");
     if (j.contains("strip_prefix")) {
         snprintf(strip_prefix_, sizeof(strip_prefix_), "%s", j["strip_prefix"].get<std::string>().c_str());
     }
@@ -112,12 +117,14 @@ void SourcePanel::load_settings(const json& j) {
 }
 
 void SourcePanel::reset_settings() {
+    TRACE_FUNCTION_CAT("ui");
     strip_prefix_[0] = '\0';
     local_base_[0] = '\0';
     path_settings_changed_ = true;
 }
 
 void SourcePanel::render_settings() {
+    TRACE_FUNCTION_CAT("ui");
     ImGui::TextWrapped("Remap source paths from the trace to your local filesystem.");
     ImGui::Spacing();
 
@@ -171,6 +178,7 @@ void SourcePanel::resolve_and_load(const std::string& raw_file) {
 }
 
 void SourcePanel::build_display_text() {
+    TRACE_FUNCTION_CAT("ui");
     cached_display_text_.clear();
     if (cached_lines_.empty()) return;
 
@@ -185,6 +193,7 @@ void SourcePanel::build_display_text() {
 }
 
 void SourcePanel::build_gutter_text() {
+    TRACE_FUNCTION_CAT("ui");
     cached_gutter_text_.clear();
     int num_lines = (int)cached_lines_.size();
     if (num_lines == 0) return;

--- a/src/ui/source_panel.cpp
+++ b/src/ui/source_panel.cpp
@@ -13,7 +13,7 @@ using json = nlohmann::json;
 
 // Try common field names for source file and line in event args
 bool extract_source_location(const TraceModel& model, const TraceEvent& ev, std::string& file, int& line) {
-    TRACE_FUNCTION_CAT("io");
+    TRACE_VERBOSE_FUNCTION_CAT("io");
     if (ev.args_idx == UINT32_MAX || ev.args_idx >= model.args().size()) return false;
 
     try {
@@ -52,7 +52,7 @@ bool extract_source_location(const TraceModel& model, const TraceEvent& ev, std:
 }
 
 static std::string normalize_slashes(const std::string& path) {
-    TRACE_FUNCTION_CAT("io");
+    TRACE_VERBOSE_FUNCTION_CAT("io");
     std::string out = path;
     for (auto& c : out) {
         if (c == '\\') c = '/';
@@ -62,7 +62,7 @@ static std::string normalize_slashes(const std::string& path) {
 
 std::string remap_source_path(const std::string& trace_path, const std::string& strip_prefix,
                               const std::string& local_base) {
-    TRACE_FUNCTION_CAT("io");
+    TRACE_VERBOSE_FUNCTION_CAT("io");
     std::string path = normalize_slashes(trace_path);
     std::string strip = normalize_slashes(strip_prefix);
     std::string base = normalize_slashes(local_base);
@@ -99,7 +99,7 @@ std::string remap_source_path(const std::string& trace_path, const std::string& 
 }
 
 json SourcePanel::save_settings() const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     json j;
     j["strip_prefix"] = strip_prefix_;
     j["local_base"] = local_base_;
@@ -107,7 +107,7 @@ json SourcePanel::save_settings() const {
 }
 
 void SourcePanel::load_settings(const json& j) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (j.contains("strip_prefix")) {
         snprintf(strip_prefix_, sizeof(strip_prefix_), "%s", j["strip_prefix"].get<std::string>().c_str());
     }
@@ -117,14 +117,14 @@ void SourcePanel::load_settings(const json& j) {
 }
 
 void SourcePanel::reset_settings() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     strip_prefix_[0] = '\0';
     local_base_[0] = '\0';
     path_settings_changed_ = true;
 }
 
 void SourcePanel::render_settings() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     ImGui::TextWrapped("Remap source paths from the trace to your local filesystem.");
     ImGui::Spacing();
 
@@ -178,7 +178,7 @@ void SourcePanel::resolve_and_load(const std::string& raw_file) {
 }
 
 void SourcePanel::build_display_text() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     cached_display_text_.clear();
     if (cached_lines_.empty()) return;
 
@@ -193,7 +193,7 @@ void SourcePanel::build_display_text() {
 }
 
 void SourcePanel::build_gutter_text() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     cached_gutter_text_.clear();
     int num_lines = (int)cached_lines_.size();
     if (num_lines == 0) return;

--- a/src/ui/stats_panel.cpp
+++ b/src/ui/stats_panel.cpp
@@ -11,7 +11,7 @@
 #include <cstring>
 
 static bool is_time_column(const std::string& name) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (name.find("dur") != std::string::npos) return true;
     if (name == "ts" || name == "min_ts" || name == "max_ts") return true;
     if (name.find("time") != std::string::npos) return true;
@@ -19,7 +19,7 @@ static bool is_time_column(const std::string& name) {
 }
 
 static void render_cell(const std::string& value, bool is_time) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (is_time) {
         char* end = nullptr;
         double v = strtod(value.c_str(), &end);
@@ -34,7 +34,7 @@ static void render_cell(const std::string& value, bool is_time) {
 }
 
 void StatsPanel::ensure_default_tab() {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     if (tabs_.empty()) {
         QueryTab tab;
         tab.title = "Hot Functions";
@@ -46,7 +46,7 @@ void StatsPanel::ensure_default_tab() {
 }
 
 nlohmann::json StatsPanel::save_tabs() const {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     nlohmann::json arr = nlohmann::json::array();
     for (const auto& tab : tabs_) {
         nlohmann::json t;
@@ -62,7 +62,7 @@ nlohmann::json StatsPanel::save_tabs() const {
 }
 
 void StatsPanel::load_tabs(const nlohmann::json& j) {
-    TRACE_FUNCTION_CAT("ui");
+    TRACE_VERBOSE_FUNCTION_CAT("ui");
     tabs_.clear();
     if (!j.is_array()) return;
     for (const auto& item : j) {

--- a/src/ui/stats_panel.cpp
+++ b/src/ui/stats_panel.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 static bool is_time_column(const std::string& name) {
+    TRACE_FUNCTION_CAT("ui");
     if (name.find("dur") != std::string::npos) return true;
     if (name == "ts" || name == "min_ts" || name == "max_ts") return true;
     if (name.find("time") != std::string::npos) return true;
@@ -18,6 +19,7 @@ static bool is_time_column(const std::string& name) {
 }
 
 static void render_cell(const std::string& value, bool is_time) {
+    TRACE_FUNCTION_CAT("ui");
     if (is_time) {
         char* end = nullptr;
         double v = strtod(value.c_str(), &end);
@@ -32,6 +34,7 @@ static void render_cell(const std::string& value, bool is_time) {
 }
 
 void StatsPanel::ensure_default_tab() {
+    TRACE_FUNCTION_CAT("ui");
     if (tabs_.empty()) {
         QueryTab tab;
         tab.title = "Hot Functions";
@@ -43,6 +46,7 @@ void StatsPanel::ensure_default_tab() {
 }
 
 nlohmann::json StatsPanel::save_tabs() const {
+    TRACE_FUNCTION_CAT("ui");
     nlohmann::json arr = nlohmann::json::array();
     for (const auto& tab : tabs_) {
         nlohmann::json t;
@@ -58,6 +62,7 @@ nlohmann::json StatsPanel::save_tabs() const {
 }
 
 void StatsPanel::load_tabs(const nlohmann::json& j) {
+    TRACE_FUNCTION_CAT("ui");
     tabs_.clear();
     if (!j.is_array()) return;
     for (const auto& item : j) {

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -233,6 +233,50 @@ TEST_F(TracingIntegration, TraceFunctionMacro) {
     EXPECT_TRUE(ev["args"].contains("func"));
 }
 
+TEST_F(TracingIntegration, VerboseMacroSkippedWhenNotVerbose) {
+    Tracer::instance().set_output(tmp_path_);
+    // verbose is off by default — verbose macros should not emit events
+    { TRACE_VERBOSE_FUNCTION_CAT("test"); }
+    { TRACE_VERBOSE_SCOPE_CAT("verbose_scope", "test"); }
+    Tracer::instance().close();
+
+    auto j = read_trace();
+    EXPECT_EQ(j["traceEvents"].size(), 0);
+}
+
+TEST_F(TracingIntegration, VerboseMacroEmitsWhenVerbose) {
+    Tracer::instance().set_output(tmp_path_);
+    Tracer::instance().set_verbose(true);
+    { TRACE_VERBOSE_FUNCTION_CAT("test"); }
+    { TRACE_VERBOSE_SCOPE_CAT("verbose_scope", "test"); }
+    Tracer::instance().close();
+    Tracer::instance().set_verbose(false);
+
+    auto j = read_trace();
+    EXPECT_EQ(j["traceEvents"].size(), 2);
+    // First event: TRACE_VERBOSE_FUNCTION_CAT — name is __PRETTY_FUNCTION__
+    auto& ev0 = j["traceEvents"][0];
+    std::string name0 = ev0["name"].get<std::string>();
+    EXPECT_NE(name0.find("VerboseMacroEmitsWhenVerbose"), std::string::npos);
+    EXPECT_EQ(ev0["cat"], "test");
+    // Second event: TRACE_VERBOSE_SCOPE_CAT
+    auto& ev1 = j["traceEvents"][1];
+    EXPECT_EQ(ev1["name"], "verbose_scope");
+    EXPECT_EQ(ev1["cat"], "test");
+}
+
+TEST_F(TracingIntegration, NonVerboseMacroStillEmitsWhenVerboseOn) {
+    // Regular macros should work regardless of verbose flag
+    Tracer::instance().set_output(tmp_path_);
+    Tracer::instance().set_verbose(true);
+    { TRACE_FUNCTION_CAT("test"); }
+    Tracer::instance().close();
+    Tracer::instance().set_verbose(false);
+
+    auto j = read_trace();
+    EXPECT_EQ(j["traceEvents"].size(), 1);
+}
+
 TEST_F(TracingIntegration, MultipleEvents) {
     Tracer::instance().set_output(tmp_path_);
     Tracer::instance().write_complete("a", "c", 100, 10);


### PR DESCRIPTION
Adds TRACE_FUNCTION_CAT / TRACE_SCOPE_CAT calls to every untraced
function across 13 source files for comprehensive profiling coverage.
Categories: app, model, io, ui, timeline.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>