### PR TITLE
fix: Instances panel - default sort descended by duration not timestamp

### DIFF
--- a/src/ui/instance_panel.cpp
+++ b/src/ui/instance_panel.cpp
@@ -97,8 +97,9 @@ void InstancePanel::render(const TraceModel& model, ViewState& view) {
                               ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable,
                           ImVec2(0, 0))) {
         ImGui::TableSetupScrollFreeze(0, 1);
-        ImGui::TableSetupColumn("Time", ImGuiTableColumnFlags_DefaultSort, 0.0f, 0);
-        ImGui::TableSetupColumn("Duration", ImGuiTableColumnFlags_None, 0.0f, 1);
+        ImGui::TableSetupColumn("Time", ImGuiTableColumnFlags_None, 0.0f, 0);
+        ImGui::TableSetupColumn(
+            "Duration", ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_PreferSortDescending, 0.0f, 1);
         ImGui::TableHeadersRow();
 
         {


### PR DESCRIPTION
## Summary

- Changed the default sort column in the Instances panel from **Time** (ascending) to **Duration** (descending)
- Moved `ImGuiTableColumnFlags_DefaultSort` from the Time column to the Duration column
- Added `ImGuiTableColumnFlags_PreferSortDescending` so the longest-running instances appear first by default

This makes it easier to spot expensive calls at a glance when selecting a function in the flame graph.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)