### PR TITLE
Fix -ns flag persisting to settings on shutdown

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -533,7 +533,7 @@ void App::save_settings() {
     j["counter_track_height"] = view_.counter_track_height();
     j["label_width"] = view_.label_width();
     j["show_flows"] = view_.show_flows();
-    j["time_unit_ns"] = view_.time_unit_ns();
+    if (!cli_time_unit_override_) j["time_unit_ns"] = view_.time_unit_ns();
     j["ruler_height"] = view_.ruler_height();
     j["proc_header_height"] = view_.proc_header_height();
     j["scrollbar_scale"] = view_.scrollbar_scale();

--- a/src/app.h
+++ b/src/app.h
@@ -28,7 +28,10 @@ public:
     void shutdown();
     void open_file(const std::string& path);
     void open_buffer(std::vector<char> data, const std::string& filename);
-    void set_time_unit_ns(bool ns) { view_.set_time_unit_ns(ns); }
+    void set_time_unit_ns(bool ns) {
+        view_.set_time_unit_ns(ns);
+        cli_time_unit_override_ = true;
+    }
 
     bool has_trace() const { return has_trace_; }
 
@@ -56,6 +59,7 @@ private:
     int settings_tab_ = 0;
     bool dark_theme_ = true;
     bool vsync_ = true;
+    bool cli_time_unit_override_ = false;
     SDL_Window* window_ = nullptr;
 
     void finish_load();


### PR DESCRIPTION
## Summary

- Added a `cli_time_unit_override_` flag to `App` that tracks whether the time unit was set via CLI (`-ns`/`-us`)
- When this flag is set, `save_settings()` skips writing `time_unit_ns` to the settings file, so the CLI flag doesn't permanently alter the user's saved preference

Closes #44

## Test plan
- [ ] Start app with `-ns` flag, close, restart without `-ns` — verify settings don't retain nanosecond mode
- [ ] Start app without flags — verify `time_unit_ns` setting is saved/loaded normally
- [ ] Toggle the checkbox in Settings UI — verify it still persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)