### PR TITLE
fix: Timeline - zoom to selection when using -ns flag needs improvement

### DIFF
--- a/src/ui/INDEX.md
+++ b/src/ui/INDEX.md
@@ -52,7 +52,7 @@ float time_to_x(double ts, float timeline_left, float timeline_width) const;
 double x_to_time(float x, float timeline_left, float timeline_width) const;
 void set_trace_bounds(double min_ts, double max_ts);
 void zoom_to_fit(double min_ts, double max_ts);
-void navigate_to_event(int32_t ev_idx, const TraceEvent& ev, double pad_factor = 0.5, double min_pad_us = 100.0);
+void navigate_to_event(int32_t ev_idx, const TraceEvent& ev, double pad_factor = 0.5, double min_pad_us = 100.0);  // min_pad_us scaled by 1/1000 when time_unit_ns
 ```
 
 ## timeline_view.h / timeline_view.cpp — main timeline: ruler, tracks, event boxes, zoom/pan, range selection

--- a/src/ui/view_state.h
+++ b/src/ui/view_state.h
@@ -157,10 +157,14 @@ public:
     }
 
     // Select an event and zoom the viewport to show it.
+    // min_pad_us is specified in microseconds; when time_unit_ns_ is set,
+    // it is automatically scaled down by 1000x so the padding is appropriate
+    // for nanosecond-resolution traces.
     void navigate_to_event(int32_t ev_idx, const TraceEvent& ev, double pad_factor = 0.5, double min_pad_us = 100.0) {
         selected_event_idx_ = ev_idx;
         pending_scroll_event_idx_ = ev_idx;
-        double pad = std::max(ev.dur * pad_factor, min_pad_us);
+        double effective_min_pad = time_unit_ns_ ? min_pad_us / 1000.0 : min_pad_us;
+        double pad = std::max(ev.dur * pad_factor, effective_min_pad);
         view_start_ts_ = ev.ts - pad;
         view_end_ts_ = ev.end_ts() + pad;
     }

--- a/tests/test_view_state.cpp
+++ b/tests/test_view_state.cpp
@@ -112,6 +112,79 @@ TEST(ViewState, NavigateToEventMinPadPreventsOverZoom) {
     EXPECT_DOUBLE_EQ(vs.view_end_ts(), 600.0);
 }
 
+TEST(ViewState, NavigateToEventNsModeScalesMinPad) {
+    ViewState vs;
+    vs.set_time_unit_ns(true);
+    TraceEvent ev;
+    ev.ts = 1000.0;
+    ev.dur = 0.05;  // 50ns = 0.05us
+
+    vs.navigate_to_event(10, ev);
+
+    // In ns mode, min_pad_us=100 is scaled to 100/1000=0.1us
+    // pad = max(0.05 * 0.5, 0.1) = 0.1
+    EXPECT_DOUBLE_EQ(vs.view_start_ts(), 1000.0 - 0.1);
+    EXPECT_DOUBLE_EQ(vs.view_end_ts(), 1000.05 + 0.1);
+}
+
+TEST(ViewState, NavigateToEventNsModeWithLargerEvent) {
+    ViewState vs;
+    vs.set_time_unit_ns(true);
+    TraceEvent ev;
+    ev.ts = 500.0;
+    ev.dur = 2.0;  // 2us event in ns mode
+
+    vs.navigate_to_event(5, ev);
+
+    // pad = max(2.0 * 0.5, 0.1) = 1.0
+    EXPECT_DOUBLE_EQ(vs.view_start_ts(), 500.0 - 1.0);
+    EXPECT_DOUBLE_EQ(vs.view_end_ts(), 502.0 + 1.0);
+}
+
+TEST(ViewState, NavigateToEventNsModeInstantEvent) {
+    ViewState vs;
+    vs.set_time_unit_ns(true);
+    TraceEvent ev;
+    ev.ts = 500.0;
+    ev.dur = 0.0;  // instant event
+
+    vs.navigate_to_event(3, ev);
+
+    // pad = max(0 * 0.5, 0.1) = 0.1 (scaled min_pad prevents zero-width viewport)
+    EXPECT_DOUBLE_EQ(vs.view_start_ts(), 499.9);
+    EXPECT_DOUBLE_EQ(vs.view_end_ts(), 500.1);
+}
+
+TEST(ViewState, NavigateToEventNsModeCustomMinPad) {
+    ViewState vs;
+    vs.set_time_unit_ns(true);
+    TraceEvent ev;
+    ev.ts = 5000.0;
+    ev.dur = 0.01;
+
+    // Custom min_pad of 1000us gets scaled to 1.0us in ns mode
+    vs.navigate_to_event(7, ev, 2.0, 1000.0);
+
+    // pad = max(0.01 * 2.0, 1.0) = 1.0
+    EXPECT_DOUBLE_EQ(vs.view_start_ts(), 5000.0 - 1.0);
+    EXPECT_DOUBLE_EQ(vs.view_end_ts(), 5000.01 + 1.0);
+}
+
+TEST(ViewState, NavigateToEventUsModeUnchanged) {
+    // Verify us mode (default) is not affected by the ns scaling
+    ViewState vs;
+    // time_unit_ns defaults to false
+    TraceEvent ev;
+    ev.ts = 1000.0;
+    ev.dur = 0.05;
+
+    vs.navigate_to_event(10, ev);
+
+    // pad = max(0.05 * 0.5, 100.0) = 100.0 (unchanged behavior)
+    EXPECT_DOUBLE_EQ(vs.view_start_ts(), 1000.0 - 100.0);
+    EXPECT_DOUBLE_EQ(vs.view_end_ts(), 1000.05 + 100.0);
+}
+
 // --- Range Selection ---
 
 TEST(ViewState, RangeSelectionDefaults) {


### PR DESCRIPTION
## Summary

- Scale `min_pad_us` by 1/1000 in `navigate_to_event()` when `time_unit_ns_` is set, so the minimum padding is appropriate for nanosecond-resolution traces instead of being 1000x too large
- The root cause: when `-ns` is used, timestamps are divided by 1000 during parsing (ns → µs), but the default `min_pad_us = 100.0` remained in microseconds — meaning the padding was 100µs = 100,000ns, vastly overshooting small nanosecond events

## Test plan

- [x] Added 5 new unit tests covering ns-mode scaling for small events, larger events, instant events, custom min_pad, and verifying us-mode is unaffected
- [x] All existing tests continue to pass

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)