### PR TITLE
fix: Flamegraph - Slivers need 3 pixel hit detection like timeline

### DIFF
--- a/src/ui/flame_graph_panel.cpp
+++ b/src/ui/flame_graph_panel.cpp
@@ -449,7 +449,14 @@ void FlameGraphPanel::render_icicle(const TraceModel& model, ViewState& view, in
             }
         }
 
-        if (hoverable && mouse.x >= x0 && mouse.x < x1 && mouse.y >= y && mouse.y < y + BAR_H) {
+        float hit_x0 = x0, hit_x1 = x1;
+        if (entry.w < 3.0f) {
+            float mid = (x0 + x1) * 0.5f;
+            hit_x0 = mid - 1.5f;
+            hit_x1 = mid + 1.5f;
+        }
+
+        if (hoverable && mouse.x >= hit_x0 && mouse.x < hit_x1 && mouse.y >= y && mouse.y < y + BAR_H) {
             hovered_idx = entry.node_idx;
             if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
                 int32_t best = find_longest_instance(model, tree.pid, tree.tid, node.name_idx);


### PR DESCRIPTION
## Summary

- Adds 3-pixel minimum hit detection area for narrow flamegraph bars (slivers), matching the existing behavior in the timeline view
- For bars narrower than 3 pixels, the hit area is expanded symmetrically around the bar's midpoint so they can be clicked/hovered reliably

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)