### PR TITLE
fix: Details Panel - Call Stack collapsed by default

### DIFF
--- a/src/ui/detail_panel.cpp
+++ b/src/ui/detail_panel.cpp
@@ -433,6 +433,8 @@ void DetailPanel::render(const TraceModel& model, ViewState& view) {
                     }
                 }
             }
+            // Default all children with sub-children to collapsed
+            stack_collapsed_ = stack_has_children_;
         }
         int stack_count = (int)cached_call_stack_.size() + (int)cached_stack_children_.size();
         bool has_stack = (ev.depth > 0 || !cached_stack_children_.empty());


### PR DESCRIPTION
## Summary
- Default the Call Stack tree in the Details Panel to collapsed instead of expanded
- When the call stack is built, initialize `stack_collapsed_` to match `stack_has_children_`, so all nodes with children start collapsed

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)